### PR TITLE
PCRE2 patches

### DIFF
--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -12,6 +12,8 @@ install_linux() {
     sudo apt-get install -ym libegl1-mesa-dev libgles2-mesa-dev
     sudo apt-get install -ym libsdl2-dev libpcap-dev libvdeplug-dev
     sudo apt-get install -ym libsdl2-ttf-dev
+    ## Remove when accepted: prospective
+    sudo apt-get install -ym libpcre2-dev
 }
 
 install_"$1"

--- a/makefile
+++ b/makefile
@@ -555,14 +555,28 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
       LIBEXT = $(LIBEXTSAVE)
     endif
   endif
+  # Find the PCRE2 library, prefer it over older PCRE
+  ifneq (,$(call find_include,pcre2))
+    ifneq (,$(call find_lib,pcre2-8))
+      OS_CCDEFS += -DHAVE_PCRE2_H
+      OS_LDFLAGS += -lpcre2-8
+      $(info using libpcre2: $(call find_lib,pcre2) $(call find_include,pcre2))
+      ifeq ($(LD_SEARCH_NEEDED),$(call need_search,pcre2))
+        OS_LDFLAGS += -L$(dir $(call find_lib,pcre2))
+      endif
+      FOUND_PCRE2=yes
+    endif
+  endif
   # Find PCRE RegEx library.
-  ifneq (,$(call find_include,pcre))
-    ifneq (,$(call find_lib,pcre))
-      OS_CCDEFS += -DHAVE_PCRE_H
-      OS_LDFLAGS += -lpcre
-      $(info using libpcre: $(call find_lib,pcre) $(call find_include,pcre))
-      ifeq ($(LD_SEARCH_NEEDED),$(call need_search,pcre))
-        OS_LDFLAGS += -L$(dir $(call find_lib,pcre))
+  ifndef FOUND_PCRE2
+    ifneq (,$(call find_include,pcre))
+      ifneq (,$(call find_lib,pcre))
+        OS_CCDEFS += -DHAVE_PCRE_H
+        OS_LDFLAGS += -lpcre
+        $(info using libpcre: $(call find_lib,pcre) $(call find_include,pcre))
+        ifeq ($(LD_SEARCH_NEEDED),$(call need_search,pcre))
+          OS_LDFLAGS += -L$(dir $(call find_lib,pcre))
+        endif
       endif
     endif
   endif

--- a/makefile
+++ b/makefile
@@ -560,9 +560,9 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
     ifneq (,$(call find_lib,pcre2-8))
       OS_CCDEFS += -DHAVE_PCRE2_H
       OS_LDFLAGS += -lpcre2-8
-      $(info using libpcre2: $(call find_lib,pcre2) $(call find_include,pcre2))
-      ifeq ($(LD_SEARCH_NEEDED),$(call need_search,pcre2))
-        OS_LDFLAGS += -L$(dir $(call find_lib,pcre2))
+      $(info using libpcre2-8: $(call find_lib,pcre2) $(call find_include,pcre2))
+      ifeq ($(LD_SEARCH_NEEDED),$(call need_search,pcre2-8))
+        OS_LDFLAGS += -L$(dir $(call find_lib,pcre2-8))
       endif
       FOUND_PCRE2=yes
     endif

--- a/scp.c
+++ b/scp.c
@@ -2911,6 +2911,7 @@ setenv ("SIM_REGEX_TYPE", "PCRE", 1);                   /* Publish regex type */
 #elif defined(HAVE_PCRE2_H)
 setenv ("SIM_REGEX_TYPE", "PCRE2", 1);                  /* Publish regex type */
 #endif
+
 sim_argv = argv;
 
 if (sim_switches & SWMASK ('T'))                        /* Command Line -T switch */

--- a/scp.c
+++ b/scp.c
@@ -2911,7 +2911,6 @@ setenv ("SIM_REGEX_TYPE", "PCRE", 1);                   /* Publish regex type */
 #elif defined(HAVE_PCRE2_H)
 setenv ("SIM_REGEX_TYPE", "PCRE2", 1);                  /* Publish regex type */
 #endif
-
 sim_argv = argv;
 
 if (sim_switches & SWMASK ('T'))                        /* Command Line -T switch */

--- a/scp.c
+++ b/scp.c
@@ -2909,7 +2909,8 @@ show_version (stdnul, NULL, NULL, 1, NULL);             /* Quietly set SIM_OSTYP
 #if defined (HAVE_PCRE_H)
 setenv ("SIM_REGEX_TYPE", "PCRE", 1);                   /* Publish regex type */
 #elif defined(HAVE_PCRE2_H)
-setenv ("SIM_REGEX_TYPE", "PCRE2", 1);                  /* Publish regex type */#endif
+setenv ("SIM_REGEX_TYPE", "PCRE2", 1);                  /* Publish regex type */
+#endif
 sim_argv = argv;
 
 if (sim_switches & SWMASK ('T'))                        /* Command Line -T switch */

--- a/sim_defs.h
+++ b/sim_defs.h
@@ -846,7 +846,7 @@ struct EXPTAB {
 #define EXP_TYP_REGEX_I         (SWMASK ('I'))      /* regular expression pattern matching should be case independent */
 #define EXP_TYP_TIME            (SWMASK ('T'))      /* halt delay is in microseconds instead of instructions */
 #if defined(USE_REGEX)
-    pcre                *regex;                         /* compiled regular expression */
+    sim_regex_t         *regex;                         /* compiled regular expression */
     int                 re_nsub;                        /* regular expression sub expression count */
 #endif
     char                *act;                           /* action string */

--- a/sim_defs.h
+++ b/sim_defs.h
@@ -150,6 +150,10 @@ extern int sim_vax_snprintf(char *buf, size_t buf_size, const char *fmt, ...);
 #if defined(HAVE_PCRE_H)
 #include <pcre.h>
 #define USE_REGEX 1
+#elif defined(HAVE_PCRE2_H)
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#define USE_REGEX 1
 #endif
 
 #if (defined (__MWERKS__) && defined (macintosh)) || defined(__DECC)
@@ -814,6 +818,18 @@ struct BRKTYPTAB {
     const char *desc;                                   /* description */
     };
 #define BRKTYPE(typ,descrip) {SWMASK(typ), descrip}
+
+/* sim_regex_t: Type alias for the appropriate PCRE package to reduce
+   conditional compiles in this header. Unfortunately, that's not the
+   case when the actual PCRE/PCRE2 functions are called in scp.c. */
+
+#if defined(HAVE_PCRE_H)
+typedef pcre sim_regex_t;
+typedef uint32 sim_regex_offs;
+#elif defined(HAVE_PCRE2_H)
+typedef pcre2_code sim_regex_t;
+typedef PCRE2_SIZE sim_regex_offs;
+#endif
 
 /* Expect rule */
 


### PR DESCRIPTION
PCRE2 support migrated over from my `simh` repo, tested with WSL and The `makefile`.

Note to self: Change default in CMake to use pcre2 when both are merged.