### PR TITLE
Add makefile support for besm6 simulator build on current macOS systems

### DIFF
--- a/makefile
+++ b/makefile
@@ -1502,7 +1502,7 @@ VAX730 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
 	${PDP11D}/pdp11_hk.c ${PDP11D}/pdp11_vh.c ${PDP11D}/pdp11_dmc.c \
 	${PDP11D}/pdp11_td.c ${PDP11D}/pdp11_tc.c ${PDP11D}/pdp11_rk.c \
 	${PDP11D}/pdp11_io_lib.c ${PDP11D}/pdp11_ch.c ${PDP11D}/pdp11_dup.c
-VAX730_OPT = -DVM_VAX -DVAX_730 -DUSE_INT64 -DUSE_ADDR64 -I VAX -I ${PDP11D} ${NETWORK_OPT}
+VAX730_OPT = -DVM_VAX -DVAX_730 -DUSE_INT64 -DUSE_ADDR64 -I ${VAXD} -I ${PDP11D} ${NETWORK_OPT}
 
 
 VAX750 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
@@ -1518,7 +1518,7 @@ VAX750 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
 	${PDP11D}/pdp11_vh.c ${PDP11D}/pdp11_dmc.c ${PDP11D}/pdp11_dup.c \
 	${PDP11D}/pdp11_td.c ${PDP11D}/pdp11_tc.c ${PDP11D}/pdp11_rk.c \
 	${PDP11D}/pdp11_io_lib.c ${PDP11D}/pdp11_ch.c
-VAX750_OPT = -DVM_VAX -DVAX_750 -DUSE_INT64 -DUSE_ADDR64 -I VAX -I ${PDP11D} ${NETWORK_OPT}
+VAX750_OPT = -DVM_VAX -DVAX_750 -DUSE_INT64 -DUSE_ADDR64 -I ${VAXD} -I ${PDP11D} ${NETWORK_OPT}
 
 
 VAX780 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
@@ -1534,7 +1534,7 @@ VAX780 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
 	${PDP11D}/pdp11_vh.c ${PDP11D}/pdp11_dmc.c ${PDP11D}/pdp11_dup.c \
 	${PDP11D}/pdp11_td.c ${PDP11D}/pdp11_tc.c ${PDP11D}/pdp11_rk.c \
 	${PDP11D}/pdp11_io_lib.c ${PDP11D}/pdp11_ch.c
-VAX780_OPT = -DVM_VAX -DVAX_780 -DUSE_INT64 -DUSE_ADDR64 -I VAX -I ${PDP11D} ${NETWORK_OPT}
+VAX780_OPT = -DVM_VAX -DVAX_780 -DUSE_INT64 -DUSE_ADDR64 -I ${VAXD} -I ${PDP11D} ${NETWORK_OPT}
 
 
 VAX8200 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
@@ -1549,7 +1549,7 @@ VAX8200 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
 	${PDP11D}/pdp11_hk.c ${PDP11D}/pdp11_vh.c ${PDP11D}/pdp11_dmc.c \
 	${PDP11D}/pdp11_td.c ${PDP11D}/pdp11_tc.c ${PDP11D}/pdp11_rk.c \
 	${PDP11D}/pdp11_io_lib.c ${PDP11D}/pdp11_ch.c ${PDP11D}/pdp11_dup.c
-VAX8200_OPT = -DVM_VAX -DVAX_820 -DUSE_INT64 -DUSE_ADDR64 -I VAX -I ${PDP11D} ${NETWORK_OPT}
+VAX8200_OPT = -DVM_VAX -DVAX_820 -DUSE_INT64 -DUSE_ADDR64 -I ${VAXD} -I ${PDP11D} ${NETWORK_OPT}
 
 
 VAX8600 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
@@ -1565,7 +1565,7 @@ VAX8600 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
 	${PDP11D}/pdp11_vh.c ${PDP11D}/pdp11_dmc.c ${PDP11D}/pdp11_dup.c \
 	${PDP11D}/pdp11_td.c ${PDP11D}/pdp11_tc.c ${PDP11D}/pdp11_rk.c \
 	${PDP11D}/pdp11_io_lib.c ${PDP11D}/pdp11_ch.c
-VAX8600_OPT = -DVM_VAX -DVAX_860 -DUSE_INT64 -DUSE_ADDR64 -I VAX -I ${PDP11D} ${NETWORK_OPT}
+VAX8600_OPT = -DVM_VAX -DVAX_860 -DUSE_INT64 -DUSE_ADDR64 -I ${VAXD} -I ${PDP11D} ${NETWORK_OPT}
 
 
 PDP10D = ${SIMHD}/PDP10
@@ -1893,7 +1893,7 @@ B5500D = ${SIMHD}/B5500
 B5500 = ${B5500D}/b5500_cpu.c ${B5500D}/b5500_io.c ${B5500D}/b5500_sys.c \
 	${B5500D}/b5500_dk.c ${B5500D}/b5500_mt.c ${B5500D}/b5500_urec.c \
 	${B5500D}/b5500_dr.c ${B5500D}/b5500_dtc.c
-B5500_OPT = -I.. -DUSE_INT64 -DB5500 -DUSE_SIM_CARD
+B5500_OPT = -I${B5500D} -DUSE_INT64 -DB5500 -DUSE_SIM_CARD
 
 BESM6D = ${SIMHD}/BESM6
 BESM6 = ${BESM6D}/besm6_cpu.c ${BESM6D}/besm6_sys.c ${BESM6D}/besm6_mmu.c \
@@ -2012,7 +2012,7 @@ KA10 = ${KA10D}/kx10_cpu.c ${KA10D}/kx10_sys.c ${KA10D}/kx10_df.c \
 	${KA10D}/kx10_rh.c ${KA10D}/kx10_imp.c ${KA10D}/ka10_tk10.c \
 	${KA10D}/ka10_mty.c ${KA10D}/ka10_imx.c ${KA10D}/ka10_ch10.c \
 	${KA10D}/ka10_stk.c ${KA10D}/ka10_ten11.c ${KA10D}/ka10_auxcpu.c \
-	$(KA10D)/ka10_pmp.c ${KA10D}/ka10_dkb.c ${KA10D}/pdp6_dct.c \
+	${KA10D}/ka10_pmp.c ${KA10D}/ka10_dkb.c ${KA10D}/pdp6_dct.c \
 	${KA10D}/pdp6_dtc.c ${KA10D}/pdp6_mtc.c ${KA10D}/pdp6_dsk.c \
 	${KA10D}/pdp6_dcs.c ${KA10D}/ka10_dpk.c ${KA10D}/kx10_dpy.c \
 	${KA10D}/ka10_ai.c ${KA10D}/ka10_iii.c ${KA10D}/kx10_disk.c \
@@ -2593,7 +2593,7 @@ ifneq (,$(call find_test,${S3D},s3))
 	$@ $(call find_test,${S3D},s3) ${TEST_ARG}
 endif
 
-sel32: $(BIN)sel32$(EXE)
+sel32: ${BIN}sel32${EXE}
 
 ${BIN}sel32${EXE}: ${SEL32} ${SIM}
 	${MKDIRBIN}

--- a/makefile
+++ b/makefile
@@ -649,12 +649,8 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
     endif
     ifneq (,$(call find_include,SDL2/SDL))
       ifneq (,$(call find_lib,SDL2))
-        ifneq (,$(findstring Haiku,$(OSTYPE)))
-          ifneq (,$(shell which sdl2-config))
-            SDLX_CONFIG = sdl2-config
-          endif
-        else
-          SDLX_CONFIG = $(realpath $(dir $(call find_include,SDL2/SDL))../../bin/sdl2-config)
+        ifneq (,$(shell which sdl2-config))
+          SDLX_CONFIG = sdl2-config
         endif
         ifneq (,$(SDLX_CONFIG))
           VIDEO_CCDEFS += -DHAVE_LIBSDL -DUSE_SIM_VIDEO `$(SDLX_CONFIG) --cflags`
@@ -669,6 +665,64 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
           $(info using libSDL2: $(call find_include,SDL2/SDL))
           ifeq (Darwin,$(OSTYPE))
             VIDEO_CCDEFS += -DSDL_MAIN_AVAILABLE
+          endif
+          ifneq (,$(and $(BESM6_BUILD), $(or $(and $(call find_include,SDL2/SDL_ttf),$(call find_lib,SDL2_ttf)), $(and $(call find_include,SDL/SDL_ttf),$(call find_lib,SDL_ttf)))))
+            FONTPATH += /usr/share/fonts /Library/Fonts /usr/lib/jvm /System/Library/Frameworks/JavaVM.framework/Versions /System/Library/Fonts C:/Windows/Fonts
+            FONTPATH := $(dir $(foreach dir,$(strip $(FONTPATH)),$(wildcard $(dir)/.)))
+            FONTNAME += DejaVuSans.ttf LucidaSansRegular.ttf FreeSans.ttf AppleGothic.ttf tahoma.ttf
+            $(info font paths are: $(FONTPATH))
+            $(info font names are: $(FONTNAME))
+            find_fontfile = $(strip $(firstword $(foreach dir,$(strip $(FONTPATH)),$(wildcard $(dir)/$(1))$(wildcard $(dir)/*/$(1))$(wildcard $(dir)/*/*/$(1))$(wildcard $(dir)/*/*/*/$(1)))))
+            find_font = $(abspath $(strip $(firstword $(foreach font,$(strip $(FONTNAME)),$(call find_fontfile,$(font))))))
+            ifneq (,$(call find_font))
+              FONTFILE=$(call find_font)
+            else
+              $(info ***)
+              $(info *** No font file available, BESM-6 video panel disabled.)
+              $(info ***)
+              $(info *** To enable the panel display please specify one of:)
+              $(info ***          a font path with FONTPATH=path)
+              $(info ***          a font name with FONTNAME=fontname.ttf)
+              $(info ***          a font file with FONTFILE=path/fontname.ttf)
+              $(info ***)
+            endif
+          endif
+          ifeq (,$(and ${VIDEO_LDFLAGS}, ${FONTFILE}, $(BESM6_BUILD)))
+            $(info *** No SDL ttf support available.  BESM-6 video panel disabled.)
+            $(info ***)
+            ifeq (Darwin,$(OSTYPE))
+              ifeq (/opt/local/bin/port,$(shell which port))
+                $(info *** Info *** Install the MacPorts libSDL2-ttf development package to provide this)
+                $(info *** Info *** functionality for your OS X system:)
+                $(info *** Info ***       # port install libsdl2-ttf-dev)
+              endif
+              ifeq (/usr/local/bin/brew,$(shell which brew))
+                ifeq (/opt/local/bin/port,$(shell which port))
+                  $(info *** Info ***)
+                  $(info *** Info *** OR)
+                  $(info *** Info ***)
+                endif
+                $(info *** Info *** Install the HomeBrew sdl2_ttf package to provide this)
+                $(info *** Info *** functionality for your OS X system:)
+                $(info *** Info ***       $$ brew install sdl2_ttf)
+              endif
+            else
+              ifneq (,$(and $(findstring Linux,$(OSTYPE)),$(call find_exe,apt-get)))
+                $(info *** Info *** Install the development components of libSDL2-ttf)
+                $(info *** Info *** packaged for your Linux operating system distribution:)
+                $(info *** Info ***        $$ sudo apt-get install libsdl2-ttf-dev)
+              else
+                $(info *** Info *** Install the development components of libSDL2-ttf packaged by your)
+                $(info *** Info *** operating system distribution and rebuild your simulator to)
+                $(info *** Info *** enable this extra functionality.)
+              endif
+            endif
+          else
+            ifneq (,$(call find_include,SDL2/SDL_ttf),$(call find_lib,SDL2_ttf))
+              $(info using libSDL2_ttf: $(call find_lib,SDL2_ttf) $(call find_include,SDL2/SDL_ttf))
+              $(info ***)
+              BESM6_PANEL_OPT = -DFONTFILE=${FONTFILE} $(filter-out -DSDL_MAIN_AVAILABLE,${VIDEO_CCDEFS}) ${VIDEO_LDFLAGS} -lSDL2_ttf
+            endif
           endif
         endif
       endif
@@ -1901,92 +1955,7 @@ BESM6 = ${BESM6D}/besm6_cpu.c ${BESM6D}/besm6_sys.c ${BESM6D}/besm6_mmu.c \
         ${BESM6D}/besm6_tty.c ${BESM6D}/besm6_panel.c ${BESM6D}/besm6_printer.c \
         ${BESM6D}/besm6_pl.c ${BESM6D}/besm6_mg.c \
         ${BESM6D}/besm6_punch.c ${BESM6D}/besm6_punchcard.c ${BESM6D}/besm6_vu.c
-
-ifneq (,$(BESM6_BUILD))
-    BESM6_OPT = -I ${BESM6D} -DUSE_INT64 $(BESM6_PANEL_OPT)
-    ifneq (,$(and ${SDLX_CONFIG},${VIDEO_LDFLAGS}, $(or $(and $(call find_include,SDL2/SDL_ttf),$(call find_lib,SDL2_ttf)), $(and $(call find_include,SDL/SDL_ttf),$(call find_lib,SDL_ttf)))))
-        FONTPATH += /usr/share/fonts /Library/Fonts /usr/lib/jvm /System/Library/Frameworks/JavaVM.framework/Versions C:/Windows/Fonts
-        FONTPATH := $(dir $(foreach dir,$(strip $(FONTPATH)),$(wildcard $(dir)/.)))
-        FONTNAME += DejaVuSans.ttf LucidaSansRegular.ttf FreeSans.ttf AppleGothic.ttf tahoma.ttf
-#cmake-insert:set(BESM6_FONT)
-#cmake-insert:foreach (fdir IN ITEMS
-#cmake-insert:            "/usr/share/fonts" "/Library/Fonts" "/usr/lib/jvm"
-#cmake-insert:            "/System/Library/Frameworks/JavaVM.framework/Versions"
-#cmake-insert:            "$ENV{WINDIR}/Fonts")
-#cmake-insert:    foreach (font IN ITEMS
-#cmake-insert:                "DejaVuSans.ttf" "LucidaSansRegular.ttf" "FreeSans.ttf" "AppleGothic.ttf" "tahoma.ttf")
-#cmake-insert:        if (EXISTS ${fdir})
-#cmake-insert:            file(GLOB_RECURSE found_font ${fdir}/${font})
-#cmake-insert:            if (found_font)
-#cmake-insert:                get_filename_component(fontfile ${found_font} ABSOLUTE)
-#cmake-insert:                list(APPEND BESM6_FONT ${fontfile})
-#cmake-insert:            endif ()
-#cmake-insert:        endif ()
-#cmake-insert:    endforeach()
-#cmake-insert:endforeach()
-#cmake-insert:
-#cmake-insert:if (NOT BESM6_FONT)
-#cmake-insert:    message("No font file available, BESM-6 video panel disabled")
-#cmake-insert:    set(BESM6_PANEL_OPT)
-#cmake-insert:endif ()
-#cmake-insert:
-#cmake-insert:if (BESM6_FONT AND WITH_VIDEO)
-#cmake-insert:    list(GET BESM6_FONT 0 BESM6_FONT)
-#cmake-insert:endif ()
-        $(info font paths are: $(FONTPATH))
-        $(info font names are: $(FONTNAME))
-        find_fontfile = $(strip $(firstword $(foreach dir,$(strip $(FONTPATH)),$(wildcard $(dir)/$(1))$(wildcard $(dir)/*/$(1))$(wildcard $(dir)/*/*/$(1))$(wildcard $(dir)/*/*/*/$(1)))))
-        find_font = $(abspath $(strip $(firstword $(foreach font,$(strip $(FONTNAME)),$(call find_fontfile,$(font))))))
-        ifneq (,$(call find_font))
-            FONTFILE=$(call find_font)
-        else
-            $(info ***)
-            $(info *** No font file available, BESM-6 video panel disabled.)
-            $(info ***)
-            $(info *** To enable the panel display please specify one of:)
-            $(info ***          a font path with FONTPATH=path)
-            $(info ***          a font name with FONTNAME=fontname.ttf)
-            $(info ***          a font file with FONTFILE=path/fontname.ttf)
-            $(info ***)
-        endif
-    endif
-    ifeq (,$(and ${VIDEO_LDFLAGS}, ${FONTFILE}, $(BESM6_BUILD)))
-        $(info *** No SDL ttf support available.  BESM-6 video panel disabled.)
-        $(info ***)
-        ifeq (Darwin,$(OSTYPE))
-          ifeq (/opt/local/bin/port,$(shell which port))
-            $(info *** Info *** Install the MacPorts libSDL2-ttf development package to provide this)
-            $(info *** Info *** functionality for your OS X system:)
-            $(info *** Info ***       # port install libsdl2-ttf-dev)
-          endif
-          ifeq (/usr/local/bin/brew,$(shell which brew))
-            ifeq (/opt/local/bin/port,$(shell which port))
-              $(info *** Info ***)
-              $(info *** Info *** OR)
-              $(info *** Info ***)
-            endif
-            $(info *** Info *** Install the HomeBrew sdl2_ttf package to provide this)
-            $(info *** Info *** functionality for your OS X system:)
-            $(info *** Info ***       $$ brew install sdl2_ttf)
-          endif
-        else
-          ifneq (,$(and $(findstring Linux,$(OSTYPE)),$(call find_exe,apt-get)))
-            $(info *** Info *** Install the development components of libSDL2-ttf)
-            $(info *** Info *** packaged for your Linux operating system distribution:)
-            $(info *** Info ***        $$ sudo apt-get install libsdl2-ttf-dev)
-          else
-            $(info *** Info *** Install the development components of libSDL2-ttf packaged by your)
-            $(info *** Info *** operating system distribution and rebuild your simulator to)
-            $(info *** Info *** enable this extra functionality.)
-          endif
-        endif
-        BESM6_OPT = -I ${BESM6D} -DUSE_INT64 
-    else ifneq (,$(and $(findstring sdl2,${VIDEO_LDFLAGS}),$(call find_include,SDL2/SDL_ttf),$(call find_lib,SDL2_ttf)))
-        $(info using libSDL2_ttf: $(call find_lib,SDL2_ttf) $(call find_include,SDL2/SDL_ttf))
-        $(info ***)
-        BESM6_PANEL_OPT = -DFONTFILE=${FONTFILE} ${VIDEO_CCDEFS} ${VIDEO_LDFLAGS} -lSDL2_ttf
-    endif
-endif
+BESM6_OPT = -I ${BESM6D} -DUSE_INT64 $(BESM6_PANEL_OPT)
 
 PDP6D = ${SIMHD}/PDP10
 ifneq (,${DISPLAY_OPT})

--- a/sim_ether.c
+++ b/sim_ether.c
@@ -964,6 +964,10 @@ t_stat eth_filter (ETH_DEV* dev, int addr_count, ETH_MAC* const addresses,
 t_stat eth_filter_hash (ETH_DEV* dev, int addr_count, ETH_MAC* const addresses,
                    ETH_BOOL all_multicast, ETH_BOOL promiscuous, ETH_MULTIHASH* const hash)
   {return SCPE_NOFNC;}
+t_stat eth_filter_hash_ex(ETH_DEV* dev, int addr_count, ETH_MAC* const addresses,
+                          ETH_BOOL all_multicast, ETH_BOOL promiscuous, 
+                          ETH_BOOL match_broadcast, ETH_MULTIHASH* const hash)
+  {return SCPE_NOFNC;}
 const char *eth_version (void)
   {return NULL;}
 int eth_devices(int max, ETH_LIST* list, ETH_BOOL framers)


### PR DESCRIPTION
Pick up minor sim_ether.c and other minor makefile changes from cmake PR which are OK and independent of the rest of that PR.