### PR TITLE
README: add note about the restricted simh/simh repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This is the codebase of SIMH, a framework and collection of computer system simu
 SIMH was created by Bob Supnik, originally at Digital Equipment Corporation, and extended by contributions of many other people.  It is now an open source project, licensed under an MIT open source license (see [LICENSE.txt](LICENSE.txt) for the specific wording).  The project gatekeepers are the members of the [SIMH Steering Group](SIMH-SG.md).  We welcome and encourage contributions from all.  Contributions will be covered by the project license.
 
 The Open SIMH code base was taken from a code base maintained by Mark Pizzolato as of 12 May 2022.  From that point onward there is no connection between that source and the Open SIMH code base.  A detailed listing of features as of that point may be found in [SIMH-V4-status](SIMH-V4-status.md).
+
+## PLEASE NOTE
+
+**Do not** contribute material taken from `github.com/simh/simh` unless you are the author of the material in question.


### PR DESCRIPTION
This hopefully will help people avoid the license issue flagged by Mark Pizzolato in the discussion of PR #53.