### PR TITLE
simh ui: replace "readline" by "editline".

### DIFF
--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -12,6 +12,7 @@ install_linux() {
     sudo apt-get install -ym libegl1-mesa-dev libgles2-mesa-dev
     sudo apt-get install -ym libsdl2-dev libpcap-dev libvdeplug-dev
     sudo apt-get install -ym libsdl2-ttf-dev
+    sudo apt-get install -ym libedit-dev
 }
 
 install_"$1"

--- a/SIMH-V4-status.md
+++ b/SIMH-V4-status.md
@@ -561,6 +561,7 @@ Ubuntu:
     # apt-get install vde2
     # apt-get install libsdl2-dev
     # apt-get install libsdl2_ttf-dev
+    # apt-get install libedit-dev
 
 #### Windows
 

--- a/makefile
+++ b/makefile
@@ -607,6 +607,18 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
       endif
     endif
   endif
+  ifneq (,$(call find_include,editline/readline))
+    OS_CCDEFS += -DHAVE_EDITLINE
+    OS_LDFLAGS += -ledit
+    ifneq (Darwin,$(OSTYPE))
+      # The doc says termcap is needed, though reality suggests
+      # otherwise.  Put it in anyway, it can't hurt.
+      ifneq (,$(call find_lib,termcap))
+        OS_LDFLAGS += -ltermcap
+      endif
+    endif
+    $(info using libedit: $(call find_include,editline/readline))
+  endif
   ifneq (,$(call find_include,utime))
     OS_CCDEFS += -DHAVE_UTIME
   endif


### PR DESCRIPTION
This avoids infecting SIMH with the GPL license, since readline, very surprisingly, is GPL rather than LGPL.

Instead we use "editline" if available at build time.