### PR TITLE
Harmonize calibration code amongst VAXen.

### DIFF
--- a/VAX/vax730_stddev.c
+++ b/VAX/vax730_stddev.c
@@ -782,9 +782,11 @@ return SCPE_OK;
 
 t_stat clk_svc (UNIT *uptr)
 {
-sim_activate_after (uptr, 10000);
-tmr_poll = sim_rtcn_calb (100, TMR_CLK);
-tmxr_poll = tmr_poll * TMXR_MULT;                       /* set mux poll */
+int32_t t;
+t = sim_rtcn_calb (clk_tps, TMR_CLK);                   /* calibrate clock */
+sim_activate_after (uptr, 1000000/clk_tps);             /* reactivate unit */
+tmr_poll = t;                                           /* set tmr poll */
+tmxr_poll = t * TMXR_MULT;                              /* set mux poll */
 return SCPE_OK;
 }
 

--- a/VAX/vax750_stddev.c
+++ b/VAX/vax750_stddev.c
@@ -777,9 +777,11 @@ return SCPE_OK;
 
 t_stat clk_svc (UNIT *uptr)
 {
-sim_activate_after (uptr, 10000);
-tmr_poll = sim_rtcn_calb (100, TMR_CLK);
-tmxr_poll = tmr_poll * TMXR_MULT;                       /* set mux poll */
+int32_t t;
+t = sim_rtcn_calb (clk_tps, TMR_CLK);                   /* calibrate clock */
+sim_activate_after (uptr, 1000000/clk_tps);             /* reactivate unit */
+tmr_poll = t;                                           /* set tmr poll */
+tmxr_poll = t * TMXR_MULT;                              /* set mux poll */
 return SCPE_OK;
 }
 

--- a/VAX/vax780_stddev.c
+++ b/VAX/vax780_stddev.c
@@ -751,9 +751,11 @@ return SCPE_OK;
 
 t_stat clk_svc (UNIT *uptr)
 {
-sim_activate_after (uptr, 10000);
-tmr_poll = sim_rtcn_calb (100, TMR_CLK);
-tmxr_poll = tmr_poll * TMXR_MULT;                       /* set mux poll */
+int32_t t;
+t = sim_rtcn_calb (clk_tps, TMR_CLK);                   /* calibrate clock */
+sim_activate_after (uptr, 1000000/clk_tps);             /* reactivate unit */
+tmr_poll = t;                                           /* set tmr poll */
+tmxr_poll = t * TMXR_MULT;                              /* set mux poll */
 return SCPE_OK;
 }
 

--- a/VAX/vax820_stddev.c
+++ b/VAX/vax820_stddev.c
@@ -784,9 +784,11 @@ return SCPE_OK;
 
 t_stat clk_svc (UNIT *uptr)
 {
-sim_activate_after (uptr, 10000);
-tmr_poll = sim_rtcn_calb (100, TMR_CLK);
-tmxr_poll = tmr_poll * TMXR_MULT;                       /* set mux poll */
+int32_t t;
+t = sim_rtcn_calb (clk_tps, TMR_CLK);                   /* calibrate clock */
+sim_activate_after (uptr, 1000000/clk_tps);             /* reactivate unit */
+tmr_poll = t;                                           /* set tmr poll */
+tmxr_poll = t * TMXR_MULT;                              /* set mux poll */
 return SCPE_OK;
 }
 

--- a/VAX/vax860_stddev.c
+++ b/VAX/vax860_stddev.c
@@ -886,9 +886,11 @@ return SCPE_OK;
 
 t_stat clk_svc (UNIT *uptr)
 {
-sim_activate_after (uptr, 10000);
-tmr_poll = sim_rtcn_calb (100, TMR_CLK);
-tmxr_poll = tmr_poll * TMXR_MULT;                       /* set mux poll */
+int32_t t;
+t = sim_rtcn_calb (clk_tps, TMR_CLK);                   /* calibrate clock */
+sim_activate_after (uptr, 1000000/clk_tps);             /* reactivate unit */
+tmr_poll = t;                                           /* set tmr poll */
+tmxr_poll = t * TMXR_MULT;                              /* set mux poll */
 return SCPE_OK;
 }
 


### PR DESCRIPTION
Take the version of the code from VAX/vax4nn_stddev.c, vax4xx_stddev.c and vax_stddev.c, and apply it to 730, 750, 780, 820 and 860.
If we can assume that clk_tps always remains 100, this can be simplified further.