### PR TITLE
AltairZ80: SS1: Fix disable after reset.

### DIFF
--- a/AltairZ80/s100_ss1.c
+++ b/AltairZ80/s100_ss1.c
@@ -178,10 +178,10 @@ typedef struct {
 RTC_REGS ss1_rtc[1] = { { 0 } };
 
 static UNIT ss1_unit[] = {
-    { UDATA (&ss1_svc, UNIT_FIX | UNIT_DISABLE | UNIT_ROABLE, 0) },
-    { UDATA (&ss1_svc, UNIT_FIX | UNIT_DISABLE | UNIT_ROABLE, 0) },
-    { UDATA (&ss1_svc, UNIT_FIX | UNIT_DISABLE | UNIT_ROABLE, 0) },
-    { UDATA (&ss1_svc, UNIT_FIX | UNIT_DISABLE | UNIT_ROABLE, 0) }
+    { UDATA (&ss1_svc, UNIT_FIX | UNIT_DISABLE | UNIT_DIS | UNIT_ROABLE, 0) },
+    { UDATA (&ss1_svc, UNIT_FIX | UNIT_DISABLE | UNIT_DIS | UNIT_ROABLE, 0) },
+    { UDATA (&ss1_svc, UNIT_FIX | UNIT_DISABLE | UNIT_DIS | UNIT_ROABLE, 0) },
+    { UDATA (&ss1_svc, UNIT_FIX | UNIT_DISABLE | UNIT_DIS | UNIT_ROABLE, 0) }
 };
 
 static REG ss1_reg[] = {
@@ -261,6 +261,11 @@ DEVICE ss1_dev = {
 static t_stat ss1_reset(DEVICE *dptr)
 {
     PNP_INFO *pnp = (PNP_INFO *)dptr->ctxt;
+
+    sim_cancel(&dptr->units[0]);
+    sim_cancel(&dptr->units[1]);
+    sim_cancel(&dptr->units[2]);
+    sim_cancel(&dptr->units[3]);
 
     if(dptr->flags & DEV_DIS) { /* Disconnect I/O Ports */
         sim_map_resource(pnp->io_base, pnp->io_size, RESOURCE_TYPE_IO, &ss1dev, "ss1dev", TRUE);

--- a/AltairZ80/wd179x.c
+++ b/AltairZ80/wd179x.c
@@ -309,6 +309,8 @@ static t_stat wd179x_reset(DEVICE *dptr)
         }
     }
 
+    wd179x_info->cmdtype = 0;
+
     return SCPE_OK;
 }
 


### PR DESCRIPTION
The CompuPro System Support 1 could not be disabled after enabled and used due to timers causing it to be busy.  Reset properly so that "set ss1 disabled" works after reset.

FYI, @psco 