### PR TITLE
Bug fixes for various video code.

### DIFF
--- a/PDP11/pdp11_ng.c
+++ b/PDP11/pdp11_ng.c
@@ -1,7 +1,7 @@
 #ifdef USE_DISPLAY
 /* pdp11_ng.c: NG, Knight vector display
 
-   Copyright (c) 2018, Lars Brinkhoff
+   Copyright (c) 2018, 2022, Lars Brinkhoff
 
    Permission is hereby granted, free of charge, to any person obtaining a
    copy of this software and associated documentation files (the "Software"),
@@ -232,11 +232,9 @@ ng_boot(int32 unit, DEVICE *dptr)
 t_stat
 ng_set_type(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-  //if ((uptr->flags & DEV_DIS) == 0)
-  //return SCPE_ALATT;
-  if (MATCH_CMD (cptr, "DAZZLE"))
+  if (MATCH_CMD (cptr, "DAZZLE") == 0)
     ng_type = TYPE_DAZZLE;
-  else if (MATCH_CMD (cptr, "LOGO"))
+  else if (MATCH_CMD (cptr, "LOGO") == 0)
     ng_type = TYPE_LOGO;
   else
     return SCPE_ARG;

--- a/display/ng.c
+++ b/display/ng.c
@@ -25,6 +25,7 @@
  */
 
 #include <string.h>
+#include <assert.h>
 #include "display.h"                    /* XY plot interface */
 #include "ng.h"
 
@@ -34,6 +35,8 @@
 #define TKGO    010000
 #define TKSTOP  020000
 
+/* Number of displays. */
+#define DISPLAYS  8
 
 static void *ng_dptr;
 static int ng_dbit;
@@ -52,12 +55,12 @@ extern void _sim_debug_device (unsigned int dbits, DEVICE* dptr, const char* fmt
 int ng_type = 0;
 int ng_scale = PIX_SCALE;
 
-static uint16 status[8];
+static uint16 status[DISPLAYS];
 static int reloc = 0;
 static int console = 0;
-static int dpc[8];
-static int x[8];
-static int y[8];
+static int dpc[DISPLAYS];
+static int x[DISPLAYS];
+static int y[DISPLAYS];
 
 static unsigned char sync_period = 0;
 static unsigned char time_out = 0;
@@ -118,6 +121,9 @@ ng_set_reloc(uint16 d)
 int
 ng_init(void *dev, int debug)
 {
+  /* Don't change this number. */
+  assert (DISPLAYS == 8);
+
   ng_dptr = dev;
   ng_dbit = debug;
   memset (status, 0, sizeof status);

--- a/sim_video.c
+++ b/sim_video.c
@@ -2056,12 +2056,14 @@ while (vid_active) {
                         event.user.code = 0;    /* Mark as done */
                         continue;
                         }
-                    vptr = vid_get_event_window (&event, event.user.windowID);
-                    if (vptr == NULL) {
-                        sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "vid_thread() - Ignored event not bound to a window\n");
-                        event.user.code = 0;    /* Mark as done */
-                        break;
+                    if (event.user.code != EVENT_OPEN) {
+                        vptr = vid_get_event_window (&event, event.user.windowID);
+                        if (vptr == NULL) {
+                            sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "vid_thread() - Ignored event not bound to a window\n");
+                            event.user.code = 0;    /* Mark as done */
+                            break;
                         }
+                    }
                     if (event.user.code == EVENT_REDRAW) {
                         vid_update (vptr);
                         event.user.code = 0;    /* Mark as done */

--- a/sim_video.c
+++ b/sim_video.c
@@ -709,6 +709,7 @@ vptr->vid_height = height;
 vptr->vid_mouse_captured = FALSE;
 vptr->vid_cursor_visible = (vptr->vid_flags & SIM_VID_INPUTCAPTURED);
 vptr->vid_blending = FALSE;
+vptr->vid_ready = FALSE;
 
 if (!vid_active) {
     vid_key_events.head = 0;


### PR DESCRIPTION
Fix some bugs that were (probably) introduced by me.

- `vid_ready` in the SIM_DISPLAY struct can be used uninitialized.  This patch sets it to FALSE right away.
- SIMH would complain about an unrecognized event, mostly when multiple windows are in use.  That's because some events come without a valid windowID field, such as OPEN_WINDOW.
- The PDP11 "NG" device had the MATCH_CMD sense reversed.
- On closer reading of code using NG, it turns out that part of the state register is separate for each display.