### PR TITLE
makefile: Make gcc and clang warnings fail builds on compile warnings

### DIFF
--- a/BESM6/besm6_disk.c
+++ b/BESM6/besm6_disk.c
@@ -541,7 +541,7 @@ void disk_format (UNIT *u)
     log_data(fmtbuf, 5);
 
     /* Печатаем идентификатор, адрес и контрольную сумму адреса. */
-    if (u->dptr->dctrl & DEB_TRC)
+    if (u->dptr->dctrl & DEB_TRC) {
         if (IS_29MB(u))
             besm6_debug ("::: формат МД %02o зона %04o память %05o skip %02o и-а-кса %010o %010o",
                          c->dev, c->zone, c->memory, ptr - memory -c ->memory,
@@ -552,6 +552,7 @@ void disk_format (UNIT *u)
                          c->dev, c->zone, c->track, c->memory, (uint32) (ptr - memory -c ->memory),
                          (int) (fmtbuf[0] >> 8 & BITS(30)),
                          (int) (fmtbuf[2] >> 14 & BITS(30)));
+    }
 }
 
 /*

--- a/BESM6/besm6_vu.c
+++ b/BESM6/besm6_vu.c
@@ -510,7 +510,7 @@ t_stat vu_event (UNIT *u)
                 while (ch == '\n' || ch == EOF);
                 
             }
-            if (0 == strncmp(vu_gost[num], DISP_END, 7)) {
+            if (0 == strncmp((char *)vu_gost[num], DISP_END, 7)) {
                 // The "dispatcher's end" card, end of card image mode.
                 memset(vu_image[num], 0, 160);
                 vu_image[num][0] = vu_image[num][40] = 0xFFF;

--- a/makefile
+++ b/makefile
@@ -257,6 +257,7 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
         endif
       endif
     else
+      OS_CCDEFS += -Werror
       ifeq (,$(findstring ++,${GCC}))
         CC_STD = -std=gnu99
       else
@@ -264,6 +265,7 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
       endif
     endif
   else
+    OS_CCDEFS += -Werror
     ifeq (Apple,$(shell ${GCC} -v /dev/null 2>&1 | grep 'Apple' | awk '{ print $$1 }'))
       COMPILER_NAME = $(shell ${GCC} -v /dev/null 2>&1 | grep 'Apple' | awk '{ print $$1 " " $$2 " " $$3 " " $$4 }')
       CLANG_VERSION = $(word 4,$(COMPILER_NAME))


### PR DESCRIPTION
This change allows CI builds to fail without detailed viewing of build output for gcc and clang builds (all modern compilers).  Thus forcing PR submitters to find these problems before PRs are merged.  This is done  by compiling with -Werror for these compilers.

We don't know how to do this for other compilers which may be able to use the makefile, so warnings there will still proceed to build successfully.