### PR TITLE
display: Fix compiler warning in NG device.

### DIFF
--- a/display/ng.c
+++ b/display/ng.c
@@ -79,6 +79,7 @@ ng_get_csr(void)
     DEBUGF("Get CSR: %06o\n", status[0]);
     return status[0];
   }
+  return 0;
 }
 
 int32


### PR DESCRIPTION
As mentioned in #88,  @louis-chretien pointed out a warning here: https://github.com/open-simh/simh/commit/2a4e4dc10d49e0c1400dabcad79620542aedba8e#commitcomment-87763038