### PR TITLE
Visual Studio Projects: Report warnings as errors so CI builds fail on warnings

### DIFF
--- a/Intel-Systems/Intel-MDS/imds_sys.c
+++ b/Intel-Systems/Intel-MDS/imds_sys.c
@@ -1,4 +1,4 @@
-/*  mds210_sys.c: multibus system interface
+/*  imds_sys.c: multibus system interface
 
     Copyright (c) 2017, William A. Beech
 

--- a/Intel-Systems/Intel-MDS/system_defs.h
+++ b/Intel-Systems/Intel-MDS/system_defs.h
@@ -87,18 +87,18 @@
 #define SBC206_NUM      0
 
 /* set the base I/O address for the iSBC 208 */
-#define SBC208_BASE     0x40
-#define SBC208_INT      INT_1
+//#define SBC208_BASE     0x40
+//#define SBC208_INT      INT_1
 #define SBC208_NUM      0
 
 /* set the base for the zx-200a disk controller */
-#define ZX200A_BASE     0x78
-#define ZX200A_INT      INT_1
+//#define ZX200A_BASE     0x78
+//#define ZX200A_INT      INT_1
 #define ZX200A_NUM      0
 
 /* set the base and size for the iSBC 464 ROM */
-#define SBC464_BASE     0xA800
-#define SBC464_SIZE     0x47FF
+//#define SBC464_BASE     0xA800
+//#define SBC464_SIZE     0x47FF
 #define SBC464_NUM      0
 
 /* set the base and size for the iSBC 064 RAM */
@@ -132,6 +132,7 @@
 #define MAXMEMSIZE          0x0FFFF             /* 8080 max memory size */
 #define MEMSIZE             (i8080_unit.capac)  /* 8080 actual memory size */
 #define ADDRMASK            (MAXMEMSIZE)        /* 8080 address mask */
+#define BYTEMASK            0xff                //byte mask
 #define MEM_ADDR_OK(x)      (((uint16) (x)) <= MEMSIZE)
 
 /* debug definitions */

--- a/Intel-Systems/common/i8255.c
+++ b/Intel-Systems/common/i8255.c
@@ -152,7 +152,7 @@ MTAB i8255_mod[] = {
 //    { MTAB_XTD | MTAB_VDV, 0, NULL, "INT", &isbc202_set_int,
 //        NULL, NULL, "Sets the interrupt number for i8255"},
     { MTAB_XTD | MTAB_VDV, 0, "PARAM", NULL, NULL, i8255_show_param, NULL, 
-        "show configured parametes for i8255" },
+        "show configured parameters for i8255" },
     { 0 }
 };
 
@@ -161,8 +161,7 @@ DEBTAB i8255_debug[] = {
     { "FLOW", DEBUG_flow },
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
+    { "XACK", DEBUG_xack },
     { NULL }
 };
 
@@ -204,7 +203,7 @@ t_stat i8255_cfg(uint16 base, uint16 devnum, uint8 dummy)
     DEVICE *dptr;
     
     dptr = find_dev (i8255_dev.name);
-    i8255_baseport[devnum] = base & 0xff;
+    i8255_baseport[devnum] = base & BYTEMASK;
     sim_printf("    i8255%d: installed at base port 0%02XH\n",
         devnum, i8255_baseport[devnum]);
     reg_dev(i8255a, i8255_baseport[devnum], devnum, 0); 
@@ -257,9 +256,7 @@ t_stat i8255_show_param (FILE *st, UNIT *uptr, int32 val, CONST void *desc)
 
 t_stat i8255_reset (DEVICE *dptr)
 {
-//    if ((dptr->flags & DEV_DIS) == 0) { // enabled
-        i8255_reset_dev();              //software reset
-//    }
+    i8255_reset_dev();              //software reset
     return SCPE_OK;
 }
 

--- a/Intel-Systems/common/ieprom.c
+++ b/Intel-Systems/common/ieprom.c
@@ -73,7 +73,7 @@ MTAB EPROM_mod[] = {
 //    { MTAB_XTD | MTAB_VDV, 0, NULL, "BASE", &isbc464_set_base,
 //        NULL, NULL, "Sets the ROM base for EPROM"               },
     { MTAB_XTD|MTAB_VDV, 0, "PARAM", NULL, NULL, &EPROM_show_param, NULL, 
-        "Parameters" },
+        "show configured parameters for iEPROM" },
     { 0 }
 };
 
@@ -83,8 +83,6 @@ DEBTAB EPROM_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
@@ -153,6 +151,7 @@ t_stat EPROM_clr(void)
 
 t_stat EPROM_reset (DEVICE *dptr)
 {
+    EPROM_clr();
     return SCPE_OK;
 }
 

--- a/Intel-Systems/common/ioc-cont.c
+++ b/Intel-Systems/common/ioc-cont.c
@@ -115,14 +115,12 @@ DEBTAB ioc_cont_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
 MTAB ioc_cont_mod[] = {
     { MTAB_XTD | MTAB_VDV, 0, "PARAM", NULL, NULL, ioc_cont_show_param, NULL, 
-        "show configured parametes for ioc_cont" },
+        "show configured parameters for ioc_cont" },
     { 0 }
 };
 
@@ -157,9 +155,9 @@ DEVICE ioc_cont_dev = {
 
 t_stat ioc_cont_cfg(uint16 base, uint16 devnum, uint8 dummy)
 {
-    sim_printf("    ioc-cont: at base port 0%02XH\n",
-        base & 0xFF);
-    ioc_cont_baseport = base & 0xff;
+    sim_printf("    ioc-cont: installed at base port 0%02XH\n",
+        base & BYTEMASK);
+    ioc_cont_baseport = base & BYTEMASK;
     reg_dev(ioc_cont0, base, 0, 0); 
     reg_dev(ioc_cont1, base + 1, 0, 0); 
     return SCPE_OK;

--- a/Intel-Systems/common/ipc-cont.c
+++ b/Intel-Systems/common/ipc-cont.c
@@ -70,14 +70,12 @@ DEBTAB ipc_cont_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
 MTAB ipc_cont_mod[] = {
     { MTAB_XTD | MTAB_VDV, 0, "PARAM", NULL, NULL, ipc_cont_show_param, NULL, 
-        "show configured parametes for ipc_cont" },
+        "show configured parameters for ipc_cont" },
     { 0 }
 };
 
@@ -112,9 +110,9 @@ DEVICE ipc_cont_dev = {
 
 t_stat ipc_cont_cfg(uint16 base, uint16 devnum, uint8 dummy)
 {
-    sim_printf("    ipc-cont: at port 0%02XH\n",
-        base & 0xFF);
-    ipc_cont_baseport = base & 0xff;
+    sim_printf("    ipc-cont: installed at base port 0%02XH\n",
+        base & BYTEMASK);
+    ipc_cont_baseport = base & BYTEMASK;
     reg_dev(ipc_cont, base, 0, 0); 
     return SCPE_OK;
 }

--- a/Intel-Systems/common/iram8.c
+++ b/Intel-Systems/common/iram8.c
@@ -70,7 +70,7 @@ MTAB RAM_mod[] = {
     { MTAB_XTD | MTAB_VDV, 0, NULL, "SIZE", &RAM_set_size,
         NULL, NULL, "Sets the size for RAM"},
     { MTAB_XTD | MTAB_VDV, 0, "PARAM", NULL, NULL, RAM_show_param, NULL, 
-        "show configured parametes for RAM" },
+        "show configured parameters for RAM" },
     { 0 }
 };
 
@@ -80,8 +80,6 @@ DEBTAB RAM_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
@@ -212,14 +210,14 @@ uint8 RAM_get_mbyte(uint16 addr)
     uint8 val;
 
     val = *((uint8 *)RAM_unit.filebuf + (addr - RAM_unit.u3));
-    return (val & 0xFF);
+    return (val & BYTEMASK);
 }
 
 /*  put a byte into memory */
 
 void RAM_put_mbyte(uint16 addr, uint8 val)
 {
-    *((uint8 *)RAM_unit.filebuf + (addr - RAM_unit.u3)) = val & 0xFF;
+    *((uint8 *)RAM_unit.filebuf + (addr - RAM_unit.u3)) = val & BYTEMASK;
     return;
 }
 

--- a/Intel-Systems/common/irq.c
+++ b/Intel-Systems/common/irq.c
@@ -78,8 +78,7 @@ DEBTAB irq_debug[] = {
     { "FLOW", DEBUG_flow },
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
+    { "XACK", DEBUG_xack },
     { NULL }
 };
 
@@ -119,7 +118,7 @@ DEVICE irq_dev = {
 t_stat irq_reset(DEVICE *dptr)
 {
 //    if (SBC_reset(NULL) == 0) { 
-        sim_printf("  Interrupt: Reset\n");
+//        sim_printf("  Interrupt: Reset\n");
         sim_activate (&irq_unit, irq_unit.wait); /* activate unit */
         return SCPE_OK;
 //    } else {

--- a/Intel-Systems/common/isbc064.c
+++ b/Intel-Systems/common/isbc064.c
@@ -37,8 +37,6 @@
 
 #include "system_defs.h"
 
-#define BASE_ADDR       u3    
-
 #define isbc064_NAME    "Intel iSBC 064 RAM Board"
 
 /* prototypes */
@@ -107,8 +105,6 @@ DEBTAB isbc064_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
@@ -155,7 +151,7 @@ t_stat isbc064_cfg(uint16 base, uint16 size, uint8 dummy)
         return SCPE_MEM;
     }
     sim_printf("    SBC064: Enabled 0%04XH bytes at base 0%04XH\n",
-        isbc064_dev.units->capac, isbc064_dev.units->BASE_ADDR);
+        isbc064_dev.units->capac, isbc064_dev.units->u3);
     return SCPE_OK;
 }
 
@@ -205,8 +201,8 @@ t_stat isbc064_set_base(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
             sim_printf("SBC064: Base error\n");
             return SCPE_ARG;     
         } else {
-            isbc064_unit.BASE_ADDR = size * 1024;
-            sim_printf("SBC064: Base=%04XH\n", isbc064_unit.BASE_ADDR);
+            isbc064_unit.u3 = size * 1024;
+            sim_printf("SBC064: Base=%04XH\n", isbc064_unit.u3);
             return SCPE_OK;
         }
     }   
@@ -219,7 +215,7 @@ t_stat isbc064_show_param (FILE *st, UNIT *uptr, int32 val, CONST void *desc)
 {
     fprintf(st, "Device %s, Base address=0%04XH, Size=0%04XH  ", 
         ((isbc064_dev.flags & DEV_DIS) == 0) ? "Enabled" : "Disabled", 
-        isbc064_unit.BASE_ADDR, isbc064_unit.capac);
+        isbc064_unit.u3, isbc064_unit.capac);
     return SCPE_OK;
 }
 
@@ -229,6 +225,7 @@ t_stat isbc064_reset (DEVICE *dptr)
 {
     if (dptr == NULL)
         return SCPE_ARG;
+    isbc064_unit.u3 = 0;                //BASE=0
     return SCPE_OK;
 }
 
@@ -238,15 +235,15 @@ uint8 isbc064_get_mbyte(uint16 addr)
 {
     uint8 val;
 
-    val = *((uint8 *)isbc064_unit.filebuf + (addr - isbc064_unit.BASE_ADDR));
-    return (val & 0xFF);
+    val = *((uint8 *)isbc064_unit.filebuf + (addr - isbc064_unit.u3));
+    return (val & BYTEMASK);
 }
 
 /*  put a byte into memory */
 
 void isbc064_put_mbyte(uint16 addr, uint8 val)
 {
-    *((uint8 *)isbc064_unit.filebuf + (addr - isbc064_unit.BASE_ADDR)) = val & 0xFF;
+    *((uint8 *)isbc064_unit.filebuf + (addr - isbc064_unit.u3)) = val & BYTEMASK;
     return;
 }
 

--- a/Intel-Systems/common/isbc201.c
+++ b/Intel-Systems/common/isbc201.c
@@ -290,7 +290,7 @@ MTAB isbc201_mod[] = {
     { MTAB_XTD | MTAB_VDV, 0, NULL, "INT", &isbc201_set_int,
         NULL, NULL, "Sets the interrupt number for iSBC201"},
     { MTAB_XTD | MTAB_VDV, 0, "PARAM", NULL, NULL, &isbc201_show_param, NULL, 
-        "show configured parametes for iSBC201" },
+        "show configured parameters for iSBC201" },
     { 0 }
 };
 
@@ -300,8 +300,6 @@ DEBTAB isbc201_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
@@ -349,7 +347,7 @@ t_stat isbc201_cfg(uint16 baseport, uint16 devnum, uint8 intnum)
         uptr->u6 = i;               //fdd unit number
         uptr->flags &= ~UNIT_ATT;
     }
-    fdc201.baseport = baseport & 0xff;  //set port
+    fdc201.baseport = baseport & BYTEMASK;  //set port
     fdc201.intnum = intnum;             //set interrupt
     fdc201.verb = 0;                    //clear verb
     reg_dev(isbc201r0, fdc201.baseport, 0, 0); //read status
@@ -392,11 +390,11 @@ t_stat isbc201_set_mode (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
     if (val & UNIT_WPMODE) {            /* write protect */
         uptr->flags |= val;
         if (fdc201.verb)
-            sim_printf("    sbc201: WP\n");
+            sim_printf("    sbc201%d: WP\n", uptr->u6);
     } else {                            /* read write */
         uptr->flags &= ~val;
         if (fdc201.verb)
-            sim_printf("    sbc201: RW\n");
+            sim_printf("    sbc201%d: RW\n", uptr->u6);
     }
     return SCPE_OK;
 }

--- a/Intel-Systems/common/isbc206.c
+++ b/Intel-Systems/common/isbc206.c
@@ -262,7 +262,7 @@ MTAB isbc206_mod[] = {
     { MTAB_XTD | MTAB_VDV, 0, NULL, "INT", &isbc206_set_int,
         NULL, NULL, "Sets the interrupt number for iSBC206"},
     { MTAB_XTD | MTAB_VDV, 0, "PARAM", NULL, NULL, &isbc206_show_param, NULL, 
-        "show configured parametes for iSBC206" },
+        "show configured parameters for iSBC206" },
     { 0 }
 };
 
@@ -272,8 +272,6 @@ DEBTAB isbc206_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
@@ -320,7 +318,7 @@ t_stat isbc206_cfg(uint16 baseport, uint16 devnum, uint8 intnum)
         uptr = isbc206_dev.units + i;
         uptr->u6 = i;               //fdd unit number
     }
-    hdc206.baseport = baseport & 0xff;  //set port
+    hdc206.baseport = baseport & BYTEMASK;  //set port
     hdc206.intnum = intnum;             //set interrupt
     hdc206.verb = 0;                    //clear verb
     reg_dev(isbc206r0, hdc206.baseport, 0, 0); //read status
@@ -381,8 +379,13 @@ t_stat isbc206_set_port(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
         return SCPE_ARG;
     result = sscanf(cptr, "%02x", &size);
     hdc206.baseport = size;
-    if (hdc206.verb)
+//    if (hdc206.verb)
         sim_printf("SBC206: Base port=%04X\n", hdc206.baseport);
+    reg_dev(isbc206r0, hdc206.baseport, 0, 0); //read status
+    reg_dev(isbc206r1, hdc206.baseport + 1, 0, 0); //read rslt type/write IOPB addr-l
+    reg_dev(isbc206r2, hdc206.baseport + 2, 0, 0); //write IOPB addr-h and start 
+    reg_dev(isbc206r3, hdc206.baseport + 3, 0, 0); //read rstl byte 
+    reg_dev(isbc206r7, hdc206.baseport + 7, 0, 0); //write reset fdc202
     return SCPE_OK;
 }
 
@@ -396,7 +399,7 @@ t_stat isbc206_set_int(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
         return SCPE_ARG;
     result = sscanf(cptr, "%02x", &size);
     hdc206.intnum = size;
-    if (hdc206.verb)
+//    if (hdc206.verb)
         sim_printf("SBC206: Interrupt number=%04X\n", hdc206.intnum);
     return SCPE_OK;
 }

--- a/Intel-Systems/common/isbc208.c
+++ b/Intel-Systems/common/isbc208.c
@@ -471,6 +471,8 @@
  
 #define isbc208_NAME    "Intel iSBC 208 Floppy Disk Controller Board"
 
+#define SBC208_INT      INT_1
+
 /* internal function prototypes */
  
 t_stat isbc208_cfg(uint16 baseport, uint16 size, uint8 devnum);
@@ -647,9 +649,7 @@ DEBTAB isbc208_debug[] = {
     { "FLOW", DEBUG_flow },
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
-    { "REG", DEBUG_reg },
+    { "XACK", DEBUG_xack },
     { NULL }
 };
  
@@ -860,8 +860,8 @@ t_stat isbc208_svc (UNIT *uptr)
             ssize = 128 << secn;    // size of sector (bytes)
             bpt = ssize * spt;      // bytes/track
             bpc = bpt * 2;          // bytes/cylinder
-//            sim_printf("208 Read: FDD=%d h=%d s=%d t=%d n=%d secsiz=%d spt=%d PCX=%04X\n",
-//                drv, h, sec, cyl, secn, ssize, spt, PCX);
+            sim_printf("208 Read: FDD=%d h=%d s=%d t=%d n=%d secsiz=%d spt=%d PCX=%04X\n",
+                drv, h, sec, cyl, secn, ssize, spt, PCX);
             if ((fddst[uptr->u6] & RDY) == 0) { // drive not ready
                 i8272_r0 = IC_ABNORM | NR | hed | drv; /* command done - Not ready error*/
                 i8272_r3 = fddst[uptr->u6];
@@ -933,7 +933,7 @@ t_stat isbc208_svc (UNIT *uptr)
                 /*
                 fp = fopen(uptr->filename, "wb"); // write out modified image
                 for (i=0; i<uptr->capac; i++) {
-                    c = *(isbc208_buf[uptr->u6] + i) & 0xFF;
+                    c = *(isbc208_buf[uptr->u6] + i) & BYTEMASK;
                     fputc(c, fp);
                 }
                 fclose(fp);
@@ -1192,7 +1192,7 @@ uint8 isbc208_r0(t_bool io, uint8 data, uint8 devnum)
             return (i8237_r0 >> 8);
         } else {                        /* low byte */
             i8237_rD++;
-            return (i8237_r0 & 0xFF);
+            return (i8237_r0 & BYTEMASK);
         }
     } else {                            /* write baseport & current address CH 0 */
         if (i8237_rD) {                 /* high byte */
@@ -1200,7 +1200,7 @@ uint8 isbc208_r0(t_bool io, uint8 data, uint8 devnum)
             i8237_r0 |= (data << 8);
         } else {                        /* low byte */
             i8237_rD++;
-            i8237_r0 = data & 0xFF;
+            i8237_r0 = data & BYTEMASK;
         }
         return 0;
     }
@@ -1214,7 +1214,7 @@ uint8 isbc208_r1(t_bool io, uint8 data, uint8 devnum)
             return (i8237_r1 >> 8);
         } else {                        /* low byte */
             i8237_rD++;
-            return (i8237_r1 & 0xFF);
+            return (i8237_r1 & BYTEMASK);
         }
     } else {                            /* write baseport & current address CH 0 */
         if (i8237_rD) {                 /* high byte */
@@ -1222,7 +1222,7 @@ uint8 isbc208_r1(t_bool io, uint8 data, uint8 devnum)
             i8237_r1 |= (data << 8);
         } else {                        /* low byte */
             i8237_rD++;
-            i8237_r1 = data & 0xFF;
+            i8237_r1 = data & BYTEMASK;
         }
         return 0;
     }
@@ -1236,7 +1236,7 @@ uint8 isbc208_r2(t_bool io, uint8 data, uint8 devnum)
             return (i8237_r2 >> 8);
         } else {                        /* low byte */
             i8237_rD++;
-            return (i8237_r2 & 0xFF);
+            return (i8237_r2 & BYTEMASK);
         }
     } else {                            /* write baseport & current address CH 1 */
         if (i8237_rD) {                 /* high byte */
@@ -1244,7 +1244,7 @@ uint8 isbc208_r2(t_bool io, uint8 data, uint8 devnum)
             i8237_r2 |= (data << 8);
         } else {                        /* low byte */
             i8237_rD++;
-            i8237_r2 = data & 0xFF;
+            i8237_r2 = data & BYTEMASK;
         }
         return 0;
     }
@@ -1258,7 +1258,7 @@ uint8 isbc208_r3(t_bool io, uint8 data, uint8 devnum)
             return (i8237_r3 >> 8);
         } else {                        /* low byte */
             i8237_rD++;
-            return (i8237_r3 & 0xFF);
+            return (i8237_r3 & BYTEMASK);
         }
     } else {                            /* write baseport & current address CH 1 */
         if (i8237_rD) {                 /* high byte */
@@ -1266,7 +1266,7 @@ uint8 isbc208_r3(t_bool io, uint8 data, uint8 devnum)
             i8237_r3 |= (data << 8);
         } else {                        /* low byte */
             i8237_rD++;
-            i8237_r3 = data & 0xFF;
+            i8237_r3 = data & BYTEMASK;
         }
         return 0;
     }
@@ -1280,7 +1280,7 @@ uint8 isbc208_r4(t_bool io, uint8 data, uint8 devnum)
             return (i8237_r4 >> 8);
         } else {                        /* low byte */
             i8237_rD++;
-            return (i8237_r4 & 0xFF);
+            return (i8237_r4 & BYTEMASK);
         }
     } else {                            /* write baseport & current address CH 2 */
         if (i8237_rD) {                 /* high byte */
@@ -1288,7 +1288,7 @@ uint8 isbc208_r4(t_bool io, uint8 data, uint8 devnum)
             i8237_r4 |= (data << 8);
         } else {                        /* low byte */
             i8237_rD++;
-            i8237_r4 = data & 0xFF;
+            i8237_r4 = data & BYTEMASK;
         }
         return 0;
     }
@@ -1302,7 +1302,7 @@ uint8 isbc208_r5(t_bool io, uint8 data, uint8 devnum)
             return (i8237_r5 >> 8);
         } else {                        /* low byte */
             i8237_rD++;
-            return (i8237_r5 & 0xFF);
+            return (i8237_r5 & BYTEMASK);
         }
     } else {                            /* write baseport & current address CH 2 */
         if (i8237_rD) {                 /* high byte */
@@ -1310,7 +1310,7 @@ uint8 isbc208_r5(t_bool io, uint8 data, uint8 devnum)
             i8237_r5 |= (data << 8);
         } else {                        /* low byte */
             i8237_rD++;
-            i8237_r5 = data & 0xFF;
+            i8237_r5 = data & BYTEMASK;
         }
         return 0;
     }
@@ -1324,7 +1324,7 @@ uint8 isbc208_r6(t_bool io, uint8 data, uint8 devnum)
             return (i8237_r6 >> 8);
         } else {                        /* low byte */
             i8237_rD++;
-            return (i8237_r6 & 0xFF);
+            return (i8237_r6 & BYTEMASK);
         }
     } else {                            /* write baseport & current address CH 3 */
         if (i8237_rD) {                 /* high byte */
@@ -1332,7 +1332,7 @@ uint8 isbc208_r6(t_bool io, uint8 data, uint8 devnum)
             i8237_r6 |= (data << 8);
         } else {                        /* low byte */
             i8237_rD++;
-            i8237_r6 = data & 0xFF;
+            i8237_r6 = data & BYTEMASK;
         }
         return 0;
     }
@@ -1346,7 +1346,7 @@ uint8 isbc208_r7(t_bool io, uint8 data, uint8 devnum)
             return (i8237_r7 >> 8);
         } else {                        /* low byte */
             i8237_rD++;
-            return (i8237_r7 & 0xFF);
+            return (i8237_r7 & BYTEMASK);
         }
     } else {                            /* write baseport & current address CH 3 */
         if (i8237_rD) {                 /* high byte */
@@ -1354,7 +1354,7 @@ uint8 isbc208_r7(t_bool io, uint8 data, uint8 devnum)
             i8237_r7 |= (data << 8);
         } else {                        /* low byte */
             i8237_rD++;
-            i8237_r7 = data & 0xFF;
+            i8237_r7 = data & BYTEMASK;
         }
         return 0;
     }
@@ -1365,7 +1365,7 @@ uint8 isbc208_r8(t_bool io, uint8 data, uint8 devnum)
     if (io == 0) {                      /* read status register */
         return (i8237_r8);
     } else {                            /* write command register */
-        i8237_r9 = data & 0xFF;
+        i8237_r9 = data & BYTEMASK;
         return 0;
     }
 }
@@ -1375,7 +1375,7 @@ uint8 isbc208_r9(t_bool io, uint8 data, uint8 devnum)
     if (io == 0) {
         return 0;
     } else {                            /* write request register */
-        i8237_rC = data & 0xFF;
+        i8237_rC = data & BYTEMASK;
         return 0;
     }
 }
@@ -1420,7 +1420,7 @@ uint8 isbc208_rB(t_bool io, uint8 data, uint8 devnum)
     if (io == 0) {
         return 0;
     } else {                            /* write mode register */
-        i8237_rA = data & 0xFF;
+        i8237_rA = data & BYTEMASK;
         return 0;
     }
 }
@@ -1480,7 +1480,7 @@ uint8 isbc208_r12(t_bool io, uint8 data, uint8 devnum)
     if (io == 0) {                      /* read interrupt status */
         return (isbc208_i);
     } else {                            /* write controller auxillary port */ 
-        isbc208_a = data & 0xFF;
+        isbc208_a = data & BYTEMASK;
         return 0;
     }
 }
@@ -1500,7 +1500,7 @@ uint8 isbc208_r14(t_bool io, uint8 data, uint8 devnum)
     if (io == 0) {
         return 0;
     } else {                            /* Low-Byte Segment Address Register */ 
-        isbc208_sr = data & 0xFF;
+        isbc208_sr = data & BYTEMASK;
         return 0;
     }
 }

--- a/Intel-Systems/common/isbc208.c
+++ b/Intel-Systems/common/isbc208.c
@@ -512,7 +512,7 @@ extern void clr_irq(int32 int_num);
 extern uint8 reg_dev(uint8 (*routine)(t_bool, uint8, uint8), uint16, uint16, uint8);
 extern uint8 unreg_dev(uint16);
 extern void multibus_put_mbyte(uint16 addr, uint8 val);
-extern int32 multibus_get_mbyte(uint16 addr);
+extern uint8 multibus_get_mbyte(uint16 addr);
  
 /* external globals */
 

--- a/Intel-Systems/common/isbc464.c
+++ b/Intel-Systems/common/isbc464.c
@@ -76,7 +76,7 @@ MTAB isbc464_mod[] = {
    { MTAB_XTD | MTAB_VDV, 0, NULL, "BASE", &isbc464_set_base,
         NULL, NULL, "Sets the ROM base for iSBC464"               },
     { MTAB_XTD|MTAB_VDV, 0, "PARAM", NULL, NULL, &isbc464_show_param, NULL, 
-        "Parameter" },
+        "show configured parameters for SBC 464" },
     { 0 }
 };
 
@@ -86,8 +86,6 @@ DEBTAB isbc464_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
@@ -231,8 +229,8 @@ t_stat isbc464_reset (DEVICE *dptr)
     if (dptr == NULL)
         return SCPE_ARG;
     if (isbc464_onetime) {
-        isbc464_dev.units->capac = SBC464_SIZE; //set default size
-        isbc464_dev.units->BASE_ADDR = SBC464_BASE; //set default base
+//        isbc464_dev.units->capac = SBC464_SIZE; //set default size
+//        isbc464_dev.units->BASE_ADDR = SBC464_BASE; //set default base
         isbc464_onetime = 0;
     }
     if ((dptr->flags & DEV_DIS) == 0) { //already enabled
@@ -246,7 +244,7 @@ t_stat isbc464_reset (DEVICE *dptr)
     } else { //disabled
         if (isbc464_dev.units->filebuf)
             free(isbc464_dev.units->filebuf);   //return allocated memory
-        sim_printf("    sbc464: Disabled\n");
+//        sim_printf("    sbc464: Disabled\n");
     }
     return SCPE_OK;
 }
@@ -272,7 +270,7 @@ uint8 isbc464_get_mbyte(uint16 addr)
     uint8 val;
 
     val = *((uint8 *)isbc464_unit.filebuf + (addr - isbc464_unit.BASE_ADDR));
-    return (val & 0xFF);
+    return (val & BYTEMASK);
 }
 
 /* end of isbc464.c */

--- a/Intel-Systems/common/multibus.c
+++ b/Intel-Systems/common/multibus.c
@@ -34,7 +34,6 @@
 
 #include "system_defs.h"
 
-#define BASE_ADDR       u3    
 #define multibus_NAME   "Intel Multibus Interface"
 
 /* function prototypes */
@@ -81,8 +80,7 @@ DEBTAB multibus_debug[] = {
     { "FLOW", DEBUG_flow },
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
+    { "XACK", DEBUG_xack },
     { NULL }
 };
 
@@ -122,7 +120,7 @@ DEVICE multibus_dev = {
 t_stat multibus_reset(DEVICE *dptr)
 {
 //    if (SBC_reset(NULL) == 0) { 
-        sim_printf("  Multibus: Reset\n");
+//        sim_printf("  Multibus: Reset\n");
         sim_activate (&multibus_unit, multibus_unit.wait); /* activate unit */
         return SCPE_OK;
 //    } else {
@@ -145,15 +143,15 @@ uint8 multibus_get_mbyte(uint16 addr)
 {
     SET_XACK(0);                        /* set no XACK */
     if ((isbc464_dev.flags & DEV_DIS) == 0) { //ROM is enabled
-        if (addr >= isbc464_dev.units->BASE_ADDR && 
-        addr < (isbc464_dev.units->BASE_ADDR + isbc464_dev.units->capac)) {
+        if (addr >= isbc464_dev.units->u3 && 
+        addr < (isbc464_dev.units->u3 + isbc464_dev.units->capac)) {
             SET_XACK(1);            //set xack
             return(isbc464_get_mbyte(addr));
         }
     }
     if ((isbc064_dev.flags & DEV_DIS) == 0) { //iSBC 064 is enabled
-        if (addr >= isbc064_dev.units->BASE_ADDR && 
-        addr < (isbc064_dev.units->BASE_ADDR + isbc064_dev.units->capac)) {
+        if (addr >= isbc064_dev.units->u3 && 
+        addr < (isbc064_dev.units->u3 + isbc064_dev.units->capac)) {
             SET_XACK(1);            //set xack
             return (isbc064_get_mbyte(addr));
         }
@@ -165,8 +163,8 @@ void multibus_put_mbyte(uint16 addr, uint8 val)
 {
     SET_XACK(0);                        /* set no XACK */
     if ((isbc064_dev.flags & DEV_DIS) == 0) { //device is enabled
-        if (addr >= isbc064_dev.units->BASE_ADDR && 
-        addr < (isbc064_dev.units->BASE_ADDR + isbc064_dev.units->capac)) {
+        if (addr >= isbc064_dev.units->u3 && 
+        addr < (isbc064_dev.units->u3 + isbc064_dev.units->capac)) {
             SET_XACK(1);            //set xack
             isbc064_put_mbyte(addr, val);
         }

--- a/Intel-Systems/common/port.c
+++ b/Intel-Systems/common/port.c
@@ -74,8 +74,7 @@ DEBTAB port_debug[] = {
     { "FLOW", DEBUG_flow },
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
+    { "XACK", DEBUG_xack },
     { NULL }
 };
 
@@ -115,7 +114,7 @@ DEVICE port_dev = {
 t_stat port_reset(DEVICE *dptr)
 {
 //    if (SBC_reset(NULL) == 0) { 
-        sim_printf("  Port: Reset\n");
+//        sim_printf("  Port: Reset\n");
         sim_activate (&port_unit, port_unit.wait); /* activate unit */
         return SCPE_OK;
 //    } else {

--- a/Intel-Systems/common/sys.c
+++ b/Intel-Systems/common/sys.c
@@ -76,6 +76,10 @@
 #define SYS_80204   11
 #define SYS_8024    12
 #define SYS_8030    13
+#define SYS_8010_0  14
+#define SYS_8010_1  15
+#define SYS_8010_2  16
+#define SYS_8010_3  17
 
 #define sys_name    "Intel MDS Configuration Controller"
 
@@ -107,6 +111,9 @@ extern t_stat EPROM_cfg(uint16 base, uint16 size, uint8 devnum);
 extern t_stat RAM_cfg(uint16 base, uint16 size, uint8 dummy);
 extern t_stat isbc064_cfg(uint16 base, uint16 size, uint8 dummy);
 extern t_stat isbc464_cfg(uint16 base, uint16 size, uint8 dummy);
+extern t_stat isbc201_cfg(uint16 base, uint16 size, uint8 dummy);
+extern t_stat isbc202_cfg(uint16 base, uint16 size, uint8 dummy);
+extern t_stat isbc208_cfg(uint16 base, uint16 size, uint8 dummy);
 extern t_stat i3214_clr(void);
 extern t_stat i8251_clr(void);
 extern t_stat i8253_clr(void);
@@ -118,12 +125,15 @@ extern t_stat EPROM_clr(void);
 extern t_stat RAM_clr(void);
 extern t_stat isbc064_clr(void);
 extern t_stat isbc464_clr(void);
+extern t_stat isbc201_clr(void);
+extern t_stat isbc202_clr(void);
+extern t_stat isbc208_clr(void);
 extern void clr_dev(void);
 
 /* globals */
 
 int     model = -1;                     //force no model
-int     mem_map = 0;                       //memory model
+int     mem_map = 0;                    //memory model
 
 typedef struct device {
     int id;
@@ -142,122 +152,153 @@ typedef struct system_model {
     SYS_DEV devices[30];
     } SYS_MODEL;
 
-#define SYS_NUM 15
+#define SYS_NUM 18
 
 SYS_MODEL models[SYS_NUM+1] = {
     {MDS_210, "MDS-210       ", 9,
 //         id           name       num arg routine       routine1      val1    val2  val3
-        {{ i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
-         { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xF0 },
+        {{ IOC_CONT,    "IOC-CONT", 1,  1, ioc_cont_cfg, ioc_cont_clr, 0xC0 },
          { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xF0 },
+         { i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
          { i8259,       "I8259",    2,  1, i8259_cfg,    i8259_clr,    0xFA,   0xFC },
-         { IOC_CONT,    "IOC-CONT", 1,  1, ioc_cont_cfg, ioc_cont_clr, 0xC0 },
          { IPC_CONT,    "IPC-CONT", 1,  1, ipc_cont_cfg, ipc_cont_clr, 0xFF },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x0000, 0x7FFF },
          { SBC464,      "SBC464",   1,  2, isbc464_cfg,  isbc464_clr,  0xA800, 0x47FF }},
          },
     {MDS_220, "MDS-220       ", 8,
-        {{ i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
-         { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xF0 },
+        {{ IOC_CONT,    "IOC-CONT", 1,  1, ioc_cont_cfg, ioc_cont_clr, 0xC0 },
          { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xF0 },
+         { i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
          { i8259,       "I8259",    2,  1, i8259_cfg,    i8259_clr,    0xFA,   0xFC },
-         { IOC_CONT,    "IOC-CONT", 1,  1, ioc_cont_cfg, ioc_cont_clr, 0xC0 },
          { IPC_CONT,    "IPC-CONT", 1,  1, ipc_cont_cfg, ipc_cont_clr, 0xFF },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x0000, 0x7FFF }} 
          },
     {MDS_225, "MDS-225       ", 8,
-        {{ i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
-         { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xF0 },
+        {{ IOC_CONT,    "IOC-CONT", 1,  1, ioc_cont_cfg, ioc_cont_clr, 0xC0 },
          { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xF0 },
+         { i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
          { i8259,       "I8259",    2,  1, i8259_cfg,    i8259_clr,    0xFA,   0xFC },
-         { IOC_CONT,    "IOC-CONT", 1,  1, ioc_cont_cfg, ioc_cont_clr, 0xC0 },
          { IPC_CONT,    "IPC-CONT", 1,  1, ipc_cont_cfg, ipc_cont_clr, 0xFF },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x0000, 0xFFFF }},
          },
     {MDS_230, "MDS-230       ", 9,
-        {{ i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
-         { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xF0 },
+        {{ IOC_CONT,    "IOC-CONT", 1,  1, ioc_cont_cfg, ioc_cont_clr, 0xC0 },   
          { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xF0 },
+         { i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
          { i8259,       "I8259",    2,  1, i8259_cfg,    i8259_clr,    0xFA,   0xFC },
-         { IOC_CONT,    "IOC-CONT", 1,  1, ioc_cont_cfg, ioc_cont_clr, 0xC0 },   
          { IPC_CONT,    "IPC-CONT", 1,  1, ipc_cont_cfg, ipc_cont_clr, 0xFF },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x0000, 0x7FFF },
          { SBC064,      "SBC064",   1,  2, isbc064_cfg,  isbc064_clr,  0x8000, 0x7FFF }},
          },
     {MDS_800, "MDS-800       ", 5,
-        {{ i3214,       "I3214",    1,  1, i3214_cfg,    i3214_clr,    0xFC },
-         { i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
+        {{ i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
+         { i3214,       "I3214",    1,  1, i3214_cfg,    i3214_clr,    0xFC },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x00FF },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0xF800, 0x07FF },
-         { SBC064,      "SBC064",   1,  2, isbc064_cfg,  isbc064_clr,  0x0000, 0x7FFF }},
+         { SBC064,      "SBC064",   1,  2, isbc064_cfg,  isbc064_clr,  0x0000, 0xFFFF }},
          },
     {MDS_810, "MDS-810       ", 6,
-        {{ i3214,       "I3214",    1,  1, i3214_cfg,    i3214_clr,    0xFC },
-         { i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
+        {{ i8251,       "I8251",    2,  1, i8251_cfg,    i8251_clr,    0xF4,   0xF6 },
+         { i3214,       "I3214",    1,  1, i3214_cfg,    i3214_clr,    0xFC },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x00FF },
          { EPROM,       "EPROM2",   1,  2, EPROM_cfg,    EPROM_clr,    0xF800, 0x07FF },
          { SBC064,      "SBC064",   1,  2, isbc064_cfg,  isbc064_clr,  0x0000, 0x7FFF },
          { SBC464,      "SBC464",   1,  2, isbc464_cfg,  isbc464_clr,  0xA800, 0x47FF }},
          },
     {SDK_80, "SDK-80         ", 4,
-        {{ i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xFA },
-         { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xF4,   0xEC },
+        {{ i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xEC,   0xF4 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xFA },       
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x1000, 0x03FF }},
          },
     {SYS_8010, "SYS-80/10    ", 4,
-        {{ i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
-         { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+        {{ i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3c00, 0x03FF }},
          },
     {SYS_8010A, "SYS-80/10A  ", 4,
-        {{ i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
-         { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+        {{ i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x1FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3c00, 0x03FF }},
          },
     {SYS_8010B, "SYS-80/10B  ", 4,
-        {{ i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
-         { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
-         { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x3FFF },
+        {{ i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+         { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x1FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3c00, 0x03FF }},
          },
     {SYS_8020, "SYS-80/20    ", 6,
-        {{ i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+        {{ i8259,       "I8259",    1,  1, i8259_cfg,    i8259_clr,    0xDA },
          { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xDC },
-         { i8255,       "I8255",    1,  1, i8255_cfg,    i8255_clr,    0xE8 },
-         { i8259,       "I8259",    1,  1, i8259_cfg,    i8259_clr,    0xDA },
+         { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x1FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3800, 0x07FF }},
          },
-    {SYS_8020-4, "SYS-80/20-4", 6,
-        {{ i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+    {SYS_80204, "SYS-80/20-4 ", 6,
+        {{ i8259,       "I8259",    1,  1, i8259_cfg,    i8259_clr,    0xDA },
          { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xDC },
-         { i8255,       "I8255",    1,  1, i8255_cfg,    i8255_clr,    0xE8 },
-         { i8259,       "I8259",    1,  1, i8259_cfg,    i8259_clr,    0xDA },
+         { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x1FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3000, 0x0FFF }},
          },
     {SYS_8024, "SYS-80/24    ", 6,
-        {{ i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+        {{ i8259,       "I8259",    1,  1, i8259_cfg,    i8259_clr,    0xDA },
          { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xDC },
-         { i8255,       "I8255",    1,  1, i8255_cfg,    i8255_clr,    0xE8 },
-         { i8259,       "I8259",    1,  1, i8259_cfg,    i8259_clr,    0xDA },
+         { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x1FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3c00, 0x03FF }},
          },
     {SYS_8030, "SYS-80/30    ", 6,
-        {{ i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+        {{ i8259,       "I8259",    1,  1, i8259_cfg,    i8259_clr,    0xDA },
          { i8253,       "I8253",    1,  1, i8253_cfg,    i8253_clr,    0xDC },
-         { i8255,       "I8255",    1,  1, i8255_cfg,    i8255_clr,    0xE8 },
-         { i8259,       "I8259",    1,  1, i8259_cfg,    i8259_clr,    0xDA },
+         { i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
          { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x1FFF },
          { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x2000, 0x3FFF }},
+         },
+    {SYS_8010_0, "SYS-80/10-0", 5,
+        {{ i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+         { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
+         { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3c00, 0x03FF },
+         { SBC064,      "SBC064",   1,  2, isbc064_cfg,  isbc064_clr,  0x0000, 0xFFFF }},
+         },
+    {SYS_8010_1, "SYS-80/10-1", 6,
+        {{ i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+         { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
+         { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3c00, 0x03FF },
+         { SBC064,      "SBC064",   1,  2, isbc064_cfg,  isbc064_clr,  0x0000, 0xFFFF },
+         { SBC201,      "SBC201",   1,  1, isbc201_cfg,  isbc201_clr,  0x78 }},
+         },
+    {SYS_8010_2, "SYS-80/10-2", 6,
+        {{ i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+         { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
+         { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3c00, 0x03FF },
+         { SBC064,      "SBC064",   1,  2, isbc064_cfg,  isbc064_clr,  0x0000, 0xFFFF },
+         { SBC202,      "SBC202",   1,  1, isbc202_cfg,  isbc202_clr,  0x78 }},
+         },
+    {SYS_8010_3, "SYS-80/10-3 ", 6,
+        {{ i8255,       "I8255",    2,  1, i8255_cfg,    i8255_clr,    0xE4,   0xE8 },
+         { i8251,       "I8251",    1,  1, i8251_cfg,    i8251_clr,    0xEC },
+         { EPROM,       "EPROM",    1,  2, EPROM_cfg,    EPROM_clr,    0x0000, 0x0FFF },
+         { RAM,         "RAM",      1,  2, RAM_cfg,      RAM_clr,      0x3c00, 0x03FF },
+         { SBC064,      "SBC064",   1,  2, isbc064_cfg,  isbc064_clr,  0x0000, 0xFFFF },
+         { SBC208,      "SBC208",   1,  1, isbc208_cfg,  isbc208_clr,  0x40 }},
          },
     {0}
     };
@@ -282,8 +323,6 @@ DEBTAB sys_debug[] = {
     { "READ", DEBUG_read },
     { "WRITE", DEBUG_write },
     { "XACK", DEBUG_xack },
-    { "LEV1", DEBUG_level1 },
-    { "LEV2", DEBUG_level2 },
     { NULL }
 };
 
@@ -328,7 +367,7 @@ t_stat sys_cfg(uint16 base, uint16 devnum, uint8 dummy)
     DEVICE *dptr;
     
     if (model == (-1)) return SCPE_ARG; //no valid config
-    sim_printf("sys_cfg: Configure %s:\n", models[model].name);
+    sim_printf("sys_cfg: Configuring an %s:\n", models[model].name);
     switch (model) {                    //set memory map type
         case 0:                         //mds-210
             mem_map = 0;                //ipb
@@ -372,6 +411,18 @@ t_stat sys_cfg(uint16 base, uint16 devnum, uint8 dummy)
         case 13:                        //sys-8030
             mem_map = 4;                //sys-8030
             break;
+        case 14:                        //sys-8010-0
+            mem_map = 4;                //sys-8010-0
+            break;
+        case 15:                        //sys-8010-1
+            mem_map = 4;                //sys-8010-1
+            break;
+        case 16:                        //sys-8010-2
+            mem_map = 4;                //sys-8010-2
+            break;
+        case 17:                        //sys-8010-3
+            mem_map = 4;                //sys-8010-3
+            break;
         default:
             return SCPE_ARG;
     }
@@ -391,13 +442,14 @@ t_stat sys_cfg(uint16 base, uint16 devnum, uint8 dummy)
                     break;
                 case 3:                 //three arguments
                     models[model].devices[i].cfg_routine (models[model].devices[i].val[j], 
-                        models[model].devices[i].val[j+1], models[model].devices[i].val[j+1] & 0xff);
+                        models[model].devices[i].val[j+1], models[model].devices[i].val[j+1] & BYTEMASK);
                     break;
                 default:
                     return SCPE_ARG;
             }
         }
     }
+    //reset_all (0);
     return SCPE_OK;
 }
 
@@ -428,7 +480,7 @@ t_stat sys_reset(DEVICE *dptr)
 {
     if (dptr == NULL)
         return SCPE_ARG;
-    sim_printf("SYS Reset\n");
+//    sim_printf("SYS Reset\n");
     sys_cfg(0, 0, 0);
     return SCPE_OK;
 }
@@ -447,7 +499,7 @@ t_stat sys_set_model (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
         if (!strncmp(cptr, models[i].name, strlen(cptr))) { //find the system
             model = models[i].id;
             strncpy(sim_name, models[i].name, 11);
-            printf("sys_set_model: Configuring %s\n", sim_name);
+            printf("sys_set_model: Configuring an %s\n", sim_name);
             switch (model) {            //set memory map type
                 case 0:                 //mds-210
                     mem_map = 0;        //ipb
@@ -491,6 +543,18 @@ t_stat sys_set_model (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
                 case 13:                //sys-8030
                     mem_map = 4;        //sys-8030
                     break;
+                case 14:                //sys-8010-0
+                    mem_map = 4;        //sys-8010-0
+                    break;
+                case 15:                //sys-8010-1
+                    mem_map = 4;        //sys-8010-1
+                    break;
+                case 16:                //sys-8010-2
+                    mem_map = 4;        //sys-8010-2
+                    break;
+                case 17:                //sys-8010-3
+                    mem_map = 4;        //sys-8010-3
+                    break;
                 default:
                     return SCPE_ARG;
             }
@@ -510,13 +574,14 @@ t_stat sys_set_model (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
                             break;
                         case 3:         //three arguments
                             models[model].devices[i].cfg_routine (models[model].devices[i].val[j], 
-                                models[model].devices[i].val[j+1], models[model].devices[i].val[j+1] & 0xff);
+                                models[model].devices[i].val[j+1], models[model].devices[i].val[j+1] & BYTEMASK);
                             break;
                         default:
                             return SCPE_ARG;
                     }
                 }
             }
+            reset_all (0);
             return SCPE_OK;
         }
     }
@@ -530,12 +595,11 @@ t_stat sys_show_model (FILE *st, UNIT *uptr, int32 val, CONST void *desc)
     
     if (uptr == NULL)
         return SCPE_ARG;
-    return SCPE_OK;
-    fprintf(st, "%s:  %d\n", models[model].name, models[model].num);
+    fprintf(st, "%s:%d devices\n", models[model].name, models[model].num);
     for (i=0; i<models[model].num; i++) {
         fprintf(st, "  %s:", models[model].devices[i].name);
-        fprintf(st, " %d", models[model].devices[i].num);
-        fprintf(st, " %d", models[model].devices[i].args);
+        fprintf(st, " %d devices", models[model].devices[i].num);
+        fprintf(st, " %d args", models[model].devices[i].args);
         for (j=0; j<models[model].devices[i].num; j++) {
             if (models[model].devices[i].args == 2)
                 fprintf(st, " 0%04XH 0%04XH", models[model].devices[i].val[j], 

--- a/Visual Studio Projects/3B2-400.vcproj
+++ b/Visual Studio Projects/3B2-400.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/3B2-700.vcproj
+++ b/Visual Studio Projects/3B2-700.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/ALTAIR.vcproj
+++ b/Visual Studio Projects/ALTAIR.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/AltairZ80.vcproj
+++ b/Visual Studio Projects/AltairZ80.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/B5500.vcproj
+++ b/Visual Studio Projects/B5500.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -132,6 +133,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/BESM6.vcproj
+++ b/Visual Studio Projects/BESM6.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/BuildROMs.vcproj
+++ b/Visual Studio Projects/BuildROMs.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/CDC1700.vcproj
+++ b/Visual Studio Projects/CDC1700.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/ECLIPSE.vcproj
+++ b/Visual Studio Projects/ECLIPSE.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/FrontPanelTest.vcproj
+++ b/Visual Studio Projects/FrontPanelTest.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/GRI.vcproj
+++ b/Visual Studio Projects/GRI.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/H316.vcproj
+++ b/Visual Studio Projects/H316.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/HP2100.vcproj
+++ b/Visual Studio Projects/HP2100.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/HP3000.vcproj
+++ b/Visual Studio Projects/HP3000.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I1401.vcproj
+++ b/Visual Studio Projects/I1401.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I1620.vcproj
+++ b/Visual Studio Projects/I1620.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I650.vcproj
+++ b/Visual Studio Projects/I650.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I701.vcproj
+++ b/Visual Studio Projects/I701.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>
@@ -129,6 +130,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I7010.vcproj
+++ b/Visual Studio Projects/I7010.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>
@@ -129,6 +130,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I704.vcproj
+++ b/Visual Studio Projects/I704.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>
@@ -129,6 +130,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I7070.vcproj
+++ b/Visual Studio Projects/I7070.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>
@@ -129,6 +130,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I7080.vcproj
+++ b/Visual Studio Projects/I7080.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>
@@ -129,6 +130,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I7090.vcproj
+++ b/Visual Studio Projects/I7090.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>
@@ -129,6 +130,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/I7094.vcproj
+++ b/Visual Studio Projects/I7094.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/IBM1130.vcproj
+++ b/Visual Studio Projects/IBM1130.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/ID16.vcproj
+++ b/Visual Studio Projects/ID16.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/ID32.vcproj
+++ b/Visual Studio Projects/ID32.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/InfoServer100.vcproj
+++ b/Visual Studio Projects/InfoServer100.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/InfoServer1000.vcproj
+++ b/Visual Studio Projects/InfoServer1000.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/InfoServer150VXT.vcproj
+++ b/Visual Studio Projects/InfoServer150VXT.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/Intel-MDS.vcproj
+++ b/Visual Studio Projects/Intel-MDS.vcproj
@@ -95,6 +95,8 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
+				Description="Running Available Tests"
+				CommandLine="Post-Build-Event.cmd Intel-Systems &quot;$(TargetDir)$(TargetName).exe&quot;"
 			/>
 		</Configuration>
 		<Configuration
@@ -184,6 +186,8 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
+				Description="Running Available Tests"
+				CommandLine="Post-Build-Event.cmd Intel-Systems &quot;$(TargetDir)$(TargetName).exe&quot;"
 			/>
 		</Configuration>
 	</Configurations>

--- a/Visual Studio Projects/Intel-MDS.vcproj
+++ b/Visual Studio Projects/Intel-MDS.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/MicroVAX1.vcproj
+++ b/Visual Studio Projects/MicroVAX1.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -135,6 +136,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/MicroVAX2.vcproj
+++ b/Visual Studio Projects/MicroVAX2.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -135,6 +136,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/MicroVAX2000.vcproj
+++ b/Visual Studio Projects/MicroVAX2000.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/MicroVAX3100.vcproj
+++ b/Visual Studio Projects/MicroVAX3100.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/MicroVAX3100M80.vcproj
+++ b/Visual Studio Projects/MicroVAX3100M80.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/MicroVAX3100e.vcproj
+++ b/Visual Studio Projects/MicroVAX3100e.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/NOVA.vcproj
+++ b/Visual Studio Projects/NOVA.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP1.vcproj
+++ b/Visual Studio Projects/PDP1.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP10-KA.vcproj
+++ b/Visual Studio Projects/PDP10-KA.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -132,6 +133,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP10-KI.vcproj
+++ b/Visual Studio Projects/PDP10-KI.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -132,6 +133,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP10-KL.vcproj
+++ b/Visual Studio Projects/PDP10-KL.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -132,6 +133,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP10-KS.vcproj
+++ b/Visual Studio Projects/PDP10-KS.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -132,6 +133,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP10.vcproj
+++ b/Visual Studio Projects/PDP10.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP11.vcproj
+++ b/Visual Studio Projects/PDP11.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP15.vcproj
+++ b/Visual Studio Projects/PDP15.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP4.vcproj
+++ b/Visual Studio Projects/PDP4.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP6.vcproj
+++ b/Visual Studio Projects/PDP6.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -132,6 +133,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP7.vcproj
+++ b/Visual Studio Projects/PDP7.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP8.vcproj
+++ b/Visual Studio Projects/PDP8.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDP9.vcproj
+++ b/Visual Studio Projects/PDP9.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/PDQ3.vcproj
+++ b/Visual Studio Projects/PDQ3.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/S3.vcproj
+++ b/Visual Studio Projects/S3.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/SAGE.vcproj
+++ b/Visual Studio Projects/SAGE.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/SDS.vcproj
+++ b/Visual Studio Projects/SDS.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/SEL32.vcproj
+++ b/Visual Studio Projects/SEL32.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -135,6 +136,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>  

--- a/Visual Studio Projects/SSEM.vcproj
+++ b/Visual Studio Projects/SSEM.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>
@@ -129,6 +130,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/TX-0.vcproj
+++ b/Visual Studio Projects/TX-0.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>
@@ -129,6 +130,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/UC15.vcproj
+++ b/Visual Studio Projects/UC15.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -130,6 +131,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 			/>
 			<Tool

--- a/Visual Studio Projects/VAX.vcproj
+++ b/Visual Studio Projects/VAX.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -135,6 +136,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAX730.vcproj
+++ b/Visual Studio Projects/VAX730.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAX750.vcproj
+++ b/Visual Studio Projects/VAX750.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAX780.vcproj
+++ b/Visual Studio Projects/VAX780.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAX8200.vcproj
+++ b/Visual Studio Projects/VAX8200.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAX8600.vcproj
+++ b/Visual Studio Projects/VAX8600.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAXstation3100M30.vcproj
+++ b/Visual Studio Projects/VAXstation3100M30.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAXstation3100M38.vcproj
+++ b/Visual Studio Projects/VAXstation3100M38.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAXstation3100M76.vcproj
+++ b/Visual Studio Projects/VAXstation3100M76.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAXstation4000M60.vcproj
+++ b/Visual Studio Projects/VAXstation4000M60.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/VAXstation4000VLC.vcproj
+++ b/Visual Studio Projects/VAXstation4000VLC.vcproj
@@ -46,6 +46,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -133,6 +134,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/alpha.vcproj
+++ b/Visual Studio Projects/alpha.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/ibmpc.vcproj
+++ b/Visual Studio Projects/ibmpc.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/ibmpcxt.vcproj
+++ b/Visual Studio Projects/ibmpcxt.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/imlac.vcproj
+++ b/Visual Studio Projects/imlac.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/lgp.vcproj
+++ b/Visual Studio Projects/lgp.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/rtVAX1000.vcproj
+++ b/Visual Studio Projects/rtVAX1000.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -135,6 +136,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/scelbi.vcproj
+++ b/Visual Studio Projects/scelbi.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/sigma.vcproj
+++ b/Visual Studio Projects/sigma.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/swtp6800mp-a.vcproj
+++ b/Visual Studio Projects/swtp6800mp-a.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/swtp6800mp-a2.vcproj
+++ b/Visual Studio Projects/swtp6800mp-a2.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>

--- a/Visual Studio Projects/tt2500.vcproj
+++ b/Visual Studio Projects/tt2500.vcproj
@@ -47,6 +47,7 @@
 				RuntimeLibrary="1"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 				ShowIncludes="false"
@@ -131,6 +132,7 @@
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
+				WarnAsError="true"
 				DebugInformationFormat="3"
 				CompileAs="1"
 			/>


### PR DESCRIPTION
Make visual studio builds fail on warnings like is done with the makefile for gcc and clang