### PR TITLE
makefile: don't use LTO

### DIFF
--- a/makefile
+++ b/makefile
@@ -1276,7 +1276,8 @@ else
   else
     NO_LTO = 1
     ifeq (Darwin,$(OSTYPE))
-      CFLAGS_O += -O4 -flto -fwhole-program
+      #CFLAGS_O += -O4 -flto -fwhole-program
+      CFLAGS_O := -O2
     else
       CFLAGS_O := -O2
     endif


### PR DESCRIPTION
Don't enable LTO when building with CLang, matching the existing practice with GCC.  This makes everything build cleanly; with LTO enabled (with either compiler) errors appear in a number of simulators.