### PR TITLE
makefile: Add explicit LTO=1 make option to force gcc and clang LTO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [pull_request]
+on: [pull_request, push]
 
 defaults:
   run:
@@ -11,16 +11,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-18.04]
+        os: [macos-12, ubuntu-20.04]
         simulators:
           # These are supposed to match ALL in makefile.
-          # Each job builds 15 simulators.
-          - pdp1 pdp4 pdp6 pdp7 pdp8 pdp9 pdp10 pdp10-ka pdp10-ki pdp10-kl pdp11 pdp15 vax microvax3900 microvax1 rtvax1000
-          - microvax2 vax730 vax750 vax780 vax8200 vax8600 microvax2000 infoserver100 infoserver150vxt microvax3100 microvax3100e vaxstation3100m30 vaxstation3100m38 vaxstation3100m76 vaxstation4000m60
-          - microvax3100m80 vaxstation4000vlc infoserver1000 nova eclipse hp2100 hp3000 i1401 i1620 s3 altair altairz80 gri i7094 ibm1130
-          - id16 id32 sds lgp h316 cdc1700 swtp6800mp-a swtp6800mp-a2 tx-0 ssem b5500
-          - besm6 imlac tt2500
-          - scelbi 3b2 i701 i704 i7010 i7070 i7080 i7090 sigma uc15 i650
+          # Each job builds ~15 simulators.
+          - pdp1 pdp4 pdp6 pdp7 pdp8 pdp9 pdp10 pdp10-ka pdp10-ki pdp10-kl pdp10-ks pdp11 pdp15 vax 
+          - microvax2 vax730 vax750 vax780 vax8200 vax8600 microvax2000 infoserver100 infoserver150vxt microvax3100 microvax3100e vaxstation3100m30 vaxstation3100m38 
+          - microvax3100m80 vaxstation4000vlc infoserver1000 nova eclipse hp2100 hp3000 i1401 i1620 s3 altair altairz80 gri i7094 
+          - id16 id32 sds lgp h316 cdc1700 swtp6800mp-a swtp6800mp-a2 tx-0 ssem b5500 sage pdq3 alpha
+          - besm6 imlac tt2500 microvax3900 microvax1 rtvax1000 vaxstation3100m76 vaxstation4000m60
+          - scelbi 3b2 i701 i704 i7010 i7070 i7080 i7090 sigma uc15 i650 sel32 intel-mds ibm1130
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -32,4 +32,4 @@ jobs:
       - name: Build
         env:
           SIM: ${{matrix.simulators}}
-        run: make $SIM
+        run: make LTO=1 $SIM


### PR DESCRIPTION
When building compiler optimized binaries with the gcc or clang compilers,
invoking GNU make with LTO=1 on the command line will cause the build
to use Link Time Optimization to maximally optimize the results.
Link Time Optimization can report errors which aren't otherwise detected
and will also take significantly longer to complete.