### PR TITLE
VIDEO: Fix bug handling a redraw event.

### DIFF
--- a/sim_video.c
+++ b/sim_video.c
@@ -2075,6 +2075,7 @@ while (vid_active) {
                                 event.user.code = 0;    /* Mark as done */
                                 continue;
                                 }
+                            vptr = vid_get_event_window (&event, event.user.windowID);
                             break;
                             }
                         }


### PR DESCRIPTION
An event pulled from the queue after redraw has been handled needs to update the vptr pointer.  The problem will only be apparent if more than one window is open.

For example, the redraw event may be followed by a draw event for another window.  If vptr is not updated, vid_draw_region will clobber state in the wrong VID_DISPLAY structure and likely cause a crash.