### PR TITLE
makefile: Make non debug builds with -O3 and LTO under gcc with -fwhole-program

### DIFF
--- a/makefile
+++ b/makefile
@@ -1270,10 +1270,10 @@ ifneq ($(DEBUG),)
   LTO =
 else
   ifneq (,$(findstring clang,$(COMPILER_NAME))$(findstring LLVM,$(COMPILER_NAME)))
-    CFLAGS_O = -O2 -fno-strict-overflow
+    CFLAGS_O = -O3 -fno-strict-overflow
     GCC_OPTIMIZERS_CMD = ${GCC} --help 2>&1
   else
-    CFLAGS_O := -O2
+    CFLAGS_O := -O3
   endif
   LDFLAGS_O = 
   GCC_MAJOR_VERSION = $(firstword $(subst  ., ,$(GCC_VERSION)))
@@ -1313,7 +1313,7 @@ else
   ifneq (,$(LTO))
     ifneq (,$(findstring -flto,$(GCC_OPTIMIZERS)))
       CFLAGS_O += -flto
-      ifneq (,$(and $(findstring gcc,$(COMPILER_NAME)),$(findstring -fwhole-program,$(GCC_OPTIMIZERS))))
+      ifneq (,$(and $(or $(findstring gcc,$(COMPILER_NAME)),$(findstring GCC,$(COMPILER_NAME))),$(findstring -fwhole-program,$(GCC_OPTIMIZERS))))
         CFLAGS_O += -fwhole-program
       endif
       LTO_FEATURE = , with Link Time Optimization,
@@ -2256,7 +2256,7 @@ endif
 
 pdp11 : ${BIN}pdp11${EXE}
 
-${BIN}pdp11${EXE} : ${PDP11} ${SIM}
+${BIN}pdp11${EXE} : ${PDP11} ${SIM} ${BUILD_ROMS}
 	${MKDIRBIN}
 	${CC} ${PDP11} ${SIM} ${PDP11_OPT} ${CC_OUTSPEC} ${LDFLAGS}
 ifneq (,$(call find_test,${PDP11D},pdp11))

--- a/makefile
+++ b/makefile
@@ -49,7 +49,10 @@
 # cause the build to use Link Time Optimization to maximally optimize 
 # the results.  Link Time Optimization can report errors which aren't 
 # otherwise detected and will also take significantly longer to 
-# complete.
+# complete.  Additionally, non debug builds default to build with an
+# optimization level of -O3.  This optimization level can be changed 
+# by invoking GNU OPTIMIZE=-O2 (or whatever optimize value you want) 
+# on the command line if desired.
 #
 # The default build will run per simulator tests if they are 
 # available.  If building without running tests is desired, 
@@ -492,7 +495,7 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
                 endif
                 OS_CCDEFS += -D_HPUX_SOURCE -D_LARGEFILE64_SOURCE
                 OS_LDFLAGS += -Wl,+b:
-                LTO =
+                override LTO =
               else
                 LIBEXT = a
               endif
@@ -1263,6 +1266,7 @@ endif
 ifneq (,$(UNSUPPORTED_BUILD))
   CFLAGS_GIT += -DSIM_BUILD=Unsupported=$(UNSUPPORTED_BUILD)
 endif
+OPTIMIZE ?= -O3
 ifneq ($(DEBUG),)
   CFLAGS_G = -g -ggdb -g3
   CFLAGS_O = -O0
@@ -1270,10 +1274,10 @@ ifneq ($(DEBUG),)
   LTO =
 else
   ifneq (,$(findstring clang,$(COMPILER_NAME))$(findstring LLVM,$(COMPILER_NAME)))
-    CFLAGS_O = -O3 -fno-strict-overflow
+    CFLAGS_O = $(OPTIMIZE) -fno-strict-overflow
     GCC_OPTIMIZERS_CMD = ${GCC} --help 2>&1
   else
-    CFLAGS_O := -O3
+    CFLAGS_O := $(OPTIMIZE)
   endif
   LDFLAGS_O = 
   GCC_MAJOR_VERSION = $(firstword $(subst  ., ,$(GCC_VERSION)))
@@ -1308,7 +1312,7 @@ else
     CFLAGS_O += -fno-strict-overflow
   endif
   ifneq (,$(findstring $(GCC_VERSION),$(LTO_EXCLUDE_VERSIONS)))
-    LTO =
+    override LTO =
   endif
   ifneq (,$(LTO))
     ifneq (,$(findstring -flto,$(GCC_OPTIMIZERS)))


### PR DESCRIPTION

- Add missing BUILD_ROMS dependency to pdp11 simulator.  ROMs don't change often so this usually didn't matter, but it should be a dependency.