### PR TITLE
makefile: don't use -fwhole-program

### DIFF
--- a/makefile
+++ b/makefile
@@ -1317,9 +1317,6 @@ else
   ifneq (,$(LTO))
     ifneq (,$(findstring -flto,$(GCC_OPTIMIZERS)))
       CFLAGS_O += -flto
-      ifneq (,$(and $(or $(findstring gcc,$(COMPILER_NAME)),$(findstring GCC,$(COMPILER_NAME))),$(findstring -fwhole-program,$(GCC_OPTIMIZERS))))
-        CFLAGS_O += -fwhole-program
-      endif
       LTO_FEATURE = , with Link Time Optimization,
     endif
   endif


### PR DESCRIPTION
The GCC documentation explicitly says not to use that option when -flto is used, and since that is the only place where the makefile was using it, remove it to conform to the documented rules.