### PR TITLE
VAX: silence compiler warning

### DIFF
--- a/VAX/vax_sysdev.c
+++ b/VAX/vax_sysdev.c
@@ -1181,9 +1181,12 @@ while (memsize > 1) {
         }
     for (i=0; boards[i].capacity > memsize; ++i)
         ;
-    fprintf(st, "Memory (@0x%08x): %3d Mbytes (%s)\n", baseaddr, boards[i].capacity, boards[i].option);
-    memsize -= boards[i].capacity;
-    baseaddr += boards[i].capacity<<20;
+    if (boards[i].option != NULL)
+    {
+        fprintf(st, "Memory (@0x%08x): %3d Mbytes (%s)\n", baseaddr, boards[i].capacity, boards[i].option);
+        memsize -= boards[i].capacity;
+        baseaddr += boards[i].capacity << 20;
+        }
     }
 return SCPE_OK;
 }


### PR DESCRIPTION
I was unable to build the vax simulator on Ubuntu 22.04 (GCC 11.3) because of a compiler warning in vax_sysdev.c. By adding a test for NULL, I was able to get the simulator to build again.