### PR TITLE
makefile: Add WARNINGS=ALLOWED make option and change default optimize to -O2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Build
         env:
           SIM: ${{matrix.simulators}}
-        run: make LTO=1 $SIM
+        run: make LTO=1 OPTIMIZE=-O3 $SIM

--- a/S3/s3_sys.c
+++ b/S3/s3_sys.c
@@ -272,7 +272,7 @@ int32 printf_sym (FILE *of, char *strg, t_addr addr, uint32 *val,
 {
 int32 c1, c2, group, len1, len2, inst, aaddr, baddr;
 int32 oplen, groupno, i, j, vpos, qbyte, da, m, n;
-char bld[128], bldaddr[96], boperand[32], aoperand[32];
+char bld[128], bldaddr[160], boperand[32], aoperand[32];
 int32 blk[16], blt[16];
 int32 blkadd;
 
@@ -575,7 +575,7 @@ switch (opcode[j].form) {                               /* Get operands based on
             if (isdigit(gbuf[0])) {
                 sscanf(gbuf, "%x", &r);
             } else {
-                for (i = 0; i < 16; i++) {
+                for (i = 0; i < 15; i++) {
                     if (strcmp(gbuf, regname[i]) == 0)
                         break;
                 }

--- a/makefile
+++ b/makefile
@@ -50,9 +50,15 @@
 # the results.  Link Time Optimization can report errors which aren't 
 # otherwise detected and will also take significantly longer to 
 # complete.  Additionally, non debug builds default to build with an
-# optimization level of -O3.  This optimization level can be changed 
-# by invoking GNU OPTIMIZE=-O2 (or whatever optimize value you want) 
+# optimization level of -O2.  This optimization level can be changed 
+# by invoking GNU OPTIMIZE=-O3 (or whatever optimize value you want) 
 # on the command line if desired.
+#
+# The default setup will fail simulator build(s) if the compile 
+# produces any warnings.  These should be cleaned up before new 
+# or changd code is accepted into the code base.  This option 
+# can be overridden if GNU make is invoked with WARNINGS=ALLOWED
+# on the command line.
 #
 # The default build will run per simulator tests if they are 
 # available.  If building without running tests is desired, 
@@ -267,7 +273,7 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
         endif
       endif
     else
-      OS_CCDEFS += -Werror
+      OS_CCDEFS += $(if $(findstring ALLOWED,$(WARNINGS)),,-Werror)
       ifeq (,$(findstring ++,${GCC}))
         CC_STD = -std=gnu99
       else
@@ -275,7 +281,7 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
       endif
     endif
   else
-    OS_CCDEFS += -Werror
+    OS_CCDEFS += $(if $(findstring ALLOWED,$(WARNINGS)),,-Werror)
     ifeq (Apple,$(shell ${GCC} -v /dev/null 2>&1 | grep 'Apple' | awk '{ print $$1 }'))
       COMPILER_NAME = $(shell ${GCC} -v /dev/null 2>&1 | grep 'Apple' | awk '{ print $$1 " " $$2 " " $$3 " " $$4 }')
       CLANG_VERSION = $(word 4,$(COMPILER_NAME))
@@ -1266,7 +1272,7 @@ endif
 ifneq (,$(UNSUPPORTED_BUILD))
   CFLAGS_GIT += -DSIM_BUILD=Unsupported=$(UNSUPPORTED_BUILD)
 endif
-OPTIMIZE ?= -O3
+OPTIMIZE ?= -O2
 ifneq ($(DEBUG),)
   CFLAGS_G = -g -ggdb -g3
   CFLAGS_O = -O0


### PR DESCRIPTION

The CI build specifies OPTIMIZE=-O3 and runs with the default where warnings are converted to errors.