### PR TITLE
Fix "non-void function does not return a value" warning

### DIFF
--- a/stub/stub_sys.c
+++ b/stub/stub_sys.c
@@ -60,6 +60,7 @@ t_bool build_dev_tab (void)
 t_stat fprint_sym (FILE *of, t_addr addr, t_value *val,
                    UNIT *uptr, int32 sw)
 {
+  return SCPE_OK;
 }
 
 t_stat parse_sym (CONST char *cptr, t_addr addr, UNIT *uptr,


### PR DESCRIPTION
Found with Debian clang version 15.0.3-2 and LTO=1.