### PR TITLE
AltairZ80: i86: Fix bugs in REPE/REPNE as well as AAM instructions.

### DIFF
--- a/AltairZ80/i86_ops.c
+++ b/AltairZ80/i86_ops.c
@@ -4321,14 +4321,12 @@ static void i86op_lock(PC_ENV *m)
 static void i86op_repne(PC_ENV *m)
 {
    m->sysmode |= SYSMODE_PREFIX_REPNE;
-   DECODE_CLEAR_SEGOVR(m);
 }
 
 /*opcode=0xf3*/
 static void i86op_repe(PC_ENV *m)
 {
    m->sysmode |= SYSMODE_PREFIX_REPE;
-   DECODE_CLEAR_SEGOVR(m);
 }
 
 /*opcode=0xf4*/

--- a/AltairZ80/i86_ops.c
+++ b/AltairZ80/i86_ops.c
@@ -4121,7 +4121,7 @@ static void i86op_opcD3_word_RM_CL(PC_ENV *m)
 /* opcode=0xd4*/
 static void i86op_aam(PC_ENV *m)
 {   uint8 a;
-    a = fetch_byte_imm(m);  /* this is a stupid encoding. */
+    a = fetch_byte_imm(m);
     if (a != 10)
         sim_printf("CPU: " ADDRESS_FORMAT " Error decoding AAM: Expected 0x0a but got 0x%2x.\n", m->Sp_regs.IP.I16_reg.x_reg, a);
     /* note the type change here --- returning AL and AH in AX. */
@@ -4132,6 +4132,10 @@ static void i86op_aam(PC_ENV *m)
 /* opcode=0xd5*/
 static void i86op_aad(PC_ENV *m)
 {
+    uint8 a;
+    a = fetch_byte_imm(m);
+    if (a != 10)
+        sim_printf("CPU: " ADDRESS_FORMAT " Error decoding AAD: Expected 0x0a but got 0x%2x.\n", m->Sp_regs.IP.I16_reg.x_reg, a);
     m->R_AX = aad_word(m,m->R_AX);
     DECODE_CLEAR_SEGOVR(m);
 }


### PR DESCRIPTION

<img width="1377" alt="REPE_5170" src="https://user-images.githubusercontent.com/264700/200152194-9bbad1a9-dd6d-4fc2-a7cb-dfa795235b31.png">
Fixed a couple of bugs in the i86 CPU core.

Verified the REPE/REPNE segment override behavior against a real 80286 CPU, and also assembled MS-DOS 2.11 from source, as well as ran CP/M-86 and rebuilt the BIOS with success.

For the AAD instruction, the next byte was not fetched, causing the instruction sequence to be corrupted.  The fix is to align the behavior with AAM.

FYI @psco as discussed.