### PR TITLE
AltairZ80: SIO: Add setFCBAddressCmd to simh_dev.

### DIFF
--- a/AltairZ80/i86_decode.c
+++ b/AltairZ80/i86_decode.c
@@ -125,7 +125,7 @@ void cpu8086_intr(uint8 intrnum)
     i86_intr_raise(&cpu8086, intrnum);
 }
 
-static void setViewRegisters(void) {
+void setViewRegisters(void) {
     FLAGS_S = cpu8086.R_FLG;
     AX_S = cpu8086.R_AX;
     BX_S = cpu8086.R_BX;


### PR DESCRIPTION
The AltairZ80 SIMH Pseudodevice provides a communication path between the host and guest operating system.  Information regarding file transfers is sent via the CP/M FCB at a fixed offset. 
 To allow non-CP/M operating systems to read/write files to the host operating system, add a command that allows the guest OS to set the FCB address.

* Allows setting the FCB address used to send filenames between the host and guest operating systems.
* Increment the SIMH device version to SIMH005.

FYI, @psco 