### PR TITLE
AltairZ80: SIO: Fix warning for type mismatch.

### DIFF
--- a/AltairZ80/altairz80_sio.c
+++ b/AltairZ80/altairz80_sio.c
@@ -166,7 +166,7 @@ extern void setClockFrequency(const uint32 Value);
 
 extern uint32 PCX;
 extern int32 SR;
-extern uint32 DS_S;
+extern int32 DS_S;
 extern UNIT cpu_unit;
 extern const char* handlerNameForPort(const int32 port);
 extern uint32 vectorInterrupt;            /* Interrupt Request */


### PR DESCRIPTION
Fix warning introduced in PR#108, per @markpizz 's [comment](https://github.com/open-simh/simh/pull/108#issuecomment-1306232744).

FYI, @markpizz , @psco 