### PR TITLE
BUILDROMS: Fix potential compiler warnings

### DIFF
--- a/I650/tests/i650_test.ini
+++ b/I650/tests/i650_test.ini
@@ -14,7 +14,7 @@ set mt debug=cmd;data;detail;exp
 set dsk debug=cmd;data;detail;exp
 
 :: Limit maximum diagnostic execution time
-runlimit 2 minutes
+runlimit 50M instructions
 set on
 on error ignore
 on runtime echof "\r\n*** Test Runtime Limit %SIM_RUNLIMIT% %SIM_RUNLIMIT_UNITS% Exceeded ***\r\n"; exit 1

--- a/PDP18B/tests/pdp9_test.ini
+++ b/PDP18B/tests/pdp9_test.ini
@@ -9,7 +9,7 @@ set cpu eae
 cd %~p0
 :: Limit maximum diagnostic execution time
 ::
-set runlimit 2 minutes
+set runlimit 10M instructions
 set on
 on error ignore
 on runtime echof "\r\n*** Test Runtime Limit %SIM_RUNLIMIT% %SIM_RUNLIMIT_UNITS% Exceeded ***\n"; exit 1

--- a/PDP8/tests/pdp8_test.ini
+++ b/PDP8/tests/pdp8_test.ini
@@ -7,7 +7,7 @@
 cd %~p0
 
 :: Limit maximum diagnostic execution time
-runlimit 2 minutes
+runlimit 1500M instructions
 set on
 on error ignore
 on runtime echof "\r\n*** Test Runtime Limit %SIM_RUNLIMIT% %SIM_RUNLIMIT_UNITS% Exceeded ***\n"; exit 1

--- a/SEL32/tests/sel32_test.ini
+++ b/SEL32/tests/sel32_test.ini
@@ -23,7 +23,7 @@ set env HOST=sel32
 ;======================================================
 ;
 ; Set run limit of 2 minutes
-set runlimit 2 minutes
+set runlimit 750M instructions
 set on
 on error ignore
 on runtime echof "\r\n*** FAILED - SEL32 Test Runtime Limit %SIM_RUNLIMIT% %SIM_RUNLIMIT_UNITS% Exceeded ***\n"; exit 1

--- a/VAX/tests/vax-diag_test.ini
+++ b/VAX/tests/vax-diag_test.ini
@@ -18,7 +18,7 @@
 #set cpu hist=20000
 #break A3B4 SHOW HIST=40
 cd %~p0
-set runlimit 2 minutes
+set runlimit 600M instructions
 set on
 on error ignore
 on runtime echof "\r\n*** Test Runtime Limit %SIM_RUNLIMIT% %SIM_RUNLIMIT_UNITS% Exceeded ***\n"; exit 1
@@ -125,8 +125,8 @@ expect "DS> " send "ATTACH KA820 HUB KA0 4096 0\r"; go -q
 expect "DS> " send "ATTACH DWBUA HUB DW0 4 5\r"; go -q
 # VAX 8200 simulates the floating point accelerator which then 
 # inspires tests to use it.  This takes more time.
-set runlimit 3 minutes
-call Common
+set runlimit 600M instructions   # Override prior runlimit
+call Common 
 call do_test EVKAB "VAX Basic Instructions Exerciser"
 call do_test EVKAC "VAX Floating Point Instructions Exerciser"
 #call do_test EVKAE "VAX Privileged Architecture Exerciser"

--- a/sim_BuildROMs.c
+++ b/sim_BuildROMs.c
@@ -90,7 +90,7 @@ struct ROM_File_Descriptor {
 #endif
 
 int sim_read_ROM_include(const char *include_filename, 
-                         int *psize,
+                         size_t *psize,
                          unsigned char **pROMData,
                          unsigned int *pchecksum,
                          char **prom_array_name,
@@ -227,7 +227,7 @@ return 1;
 }
 
 int sim_make_ROM_include(const char *rom_filename,
-                         int expected_size,
+                         size_t expected_size,
                          unsigned int expected_checksum,
                          const char *include_filename, 
                          const char *rom_array_name,
@@ -237,7 +237,7 @@ FILE *rFile;
 FILE *iFile;
 time_t now;
 int bytes_written = 0;
-int include_bytes;
+size_t include_bytes;
 int c;
 int rom;
 struct stat statb;
@@ -275,8 +275,8 @@ if (stat (rom_filename, &statb)) {
     fclose (rFile);
     return -1;
     }
-if (statb.st_size != expected_size) {
-    printf ("Error: ROM file '%s' has an unexpected size: %d vs %d\n", rom_filename, (int)statb.st_size, expected_size);
+if ((size_t)statb.st_size != (size_t)expected_size) {
+    printf ("Error: ROM file '%s' has an unexpected size: %d vs %d\n", rom_filename, (int)statb.st_size, (int)expected_size);
     printf ("This can happen if the file was transferred or unpacked incorrectly\n");
     printf ("and in the process tried to convert line endings rather than passing\n");
     printf ("the file's contents unmodified\n");


### PR DESCRIPTION
If the Appveyor Windows CI build were working we'd have problems with these warnings.

The makefile build of BuildROMs doesn't use it as a normal make target but instead compiles and runs it under the covers without the CFLAGS values.  This is OK since it really isn't a target, but a pre-build sanity check to confirm the ROM inputs haven't changed.