### PR TITLE
Fix AltairZ80: raise_scp300f_interrupt (not/un)defined #116

### DIFF
--- a/AltairZ80/s100_djhdc.c
+++ b/AltairZ80/s100_djhdc.c
@@ -112,6 +112,8 @@
 #define DJHDC_IOPB_LINK_H   14
 #define DJHDC_IOPB_LINK_E   15
 
+#define DJHDC_INT         1   /* DJHDC interrupts tied to VI1 */
+
 typedef struct {
     UNIT *uptr;
     DISK_INFO *imd;
@@ -205,7 +207,10 @@ static t_stat djhdc_detach(UNIT *uptr);
 static t_stat djhdc_unit_set_geometry(UNIT* uptr, int32 value, CONST char* cptr, void* desc);
 static t_stat djhdc_unit_show_geometry(FILE* st, UNIT* uptr, int32 value, CONST void* desc);
 static int DJHDC_Validate_CHSN(DJHDC_DRIVE_INFO* pDrive);
+#ifdef DJHDC_INTERRUPTS
 static void raise_djhdc_interrupt(void);
+#endif /* DJHDC_INTERRUPTS */
+
 static const char* djhdc_description(DEVICE *dptr);
 
 static int32 djhdcdev(const int32 port, const int32 io, const int32 data);
@@ -849,12 +854,11 @@ static int DJHDC_Validate_CHSN(DJHDC_DRIVE_INFO* pDrive)
     return (status);
 }
 
-#define VI1_INT         1   /* DJHDC interrupts tied to VI1 */
-
+#ifdef DJHDC_INTERRUPTS
 static void raise_djhdc_interrupt(void)
 {
     sim_debug(IRQ_MSG, &djhdc_dev, DEV_NAME ": " ADDRESS_FORMAT " Interrupt\n", PCX);
 
-    raise_scp300f_interrupt(VI1_INT);
-
+    raise_scp300f_interrupt(DJHDC_INT);
 }
+#endif /* DJHDC_INTERRUPTS */

--- a/AltairZ80/s100_tdd.c
+++ b/AltairZ80/s100_tdd.c
@@ -64,7 +64,6 @@ typedef struct {
 extern WD179X_INFO_PUB *wd179x_infop;
 
 static TDD_INFO tdd_info_data = { { 0x0000, 0, TDD_IO_BASE, TDD_IO_SIZE } };
-static TDD_INFO *tdd_info = &tdd_info_data;
 
 extern t_stat set_iobase(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 extern t_stat show_iobase(FILE *st, UNIT *uptr, int32 val, CONST void *desc);


### PR DESCRIPTION
This pull request addresses bug #116 and also removes an unused variable identified by @psco.

FYI, @pkoning2 , @bscottm 