### PR TITLE
AltairZ80: Add CP/M DDT-style stopped display option

### DIFF
--- a/AltairZ80/altairz80_defs.h
+++ b/AltairZ80/altairz80_defs.h
@@ -83,6 +83,8 @@ typedef enum {
 #define UNIT_CPU_STOPONHALT     (1 << UNIT_CPU_V_STOPONHALT)
 #define UNIT_CPU_V_SWITCHER     (UNIT_V_UF+6)               /* switcher 8086 <--> 8080/Z80 enabled          */
 #define UNIT_CPU_SWITCHER       (1 << UNIT_CPU_V_SWITCHER)
+#define UNIT_CPU_V_DDT          (UNIT_V_UF+7)               /* use DDT-style stop messages                  */
+#define UNIT_CPU_DDT            (1 << UNIT_CPU_V_DDT)
 
 #define ADDRESS_FORMAT          "[0x%08x]"
 

--- a/scp.c
+++ b/scp.c
@@ -9433,6 +9433,10 @@ t_stat r = 0;
 t_addr k;
 t_value pcval;
 
+if ((sim_vm_fprint_stopped != NULL) &&                  /* if a VM-specific handler is defined */
+    (!sim_vm_fprint_stopped (st, v)))                   /*   call it; if it returned FALSE, */
+    return;                                             /*     we're done */
+
 fputc ('\n', st);                                       /* start on a new line */
 
 if (v >= SCPE_BASE)                                     /* SCP error? */
@@ -9442,9 +9446,6 @@ else {                                                  /* VM error */
         fputs (sim_stop_messages [v], st);              /* print the VM-specific message */
     else
         fprintf (st, "Unknown %s simulator stop code %d", sim_name, v);
-    if ((sim_vm_fprint_stopped != NULL) &&              /* if a VM-specific stop handler is defined */
-        (!sim_vm_fprint_stopped (st, v)))               /*   call it; if it returned FALSE, */
-        return;                                         /*     we're done */
     }
 
 fprintf (st, ", %s: ", pc->name);                       /* print the name of the PC register */


### PR DESCRIPTION
SCP supports custom stopped message generation by setting `sim_vm_fprint_stopped`.  This PR first changes how `sim_vm_fprint_stopped` is processed. Prior to this PR, `sim_vm_fprint_stopped` was only used if the stop status was an SCP error (>= SCPE_BASE).  This would ignore `sim_vm_fprint_stopped` when, for example, single-stepping. This PR changes `fprint_stopped_gen()` to always invoke `sim_vm_fprint_stopped` if it is set.  If the `sim_vm_fprint_stopped` handler returns FALSE, `fprint_stop_gen()` does not continue with the standard output. This puts more control in the hands of the VM rather than SCP.

This PR also adds a "DDT" option to the CPU device that implements `sim_vm_fprint_stopped` with CP/M DDT-style stop output.

```
"SET CPU DDT" output:

Simulation stopped
C0Z1M0E1I1 A=02 B=007F D=DF06 H=EA0E S=EA37 P=FA6B ANI 01h

"SET CPU NODDT" output:

Simulation stopped, PC: 0FA6B (ANI 01h)
```

This output is the same as the output already generated by "SHOW HISTORY" so this PR also changes how the DDT output is displayed.

It is important to note that it appears no other VMs use the `sim_vm_fprint_stopped` feature, so changing its implementation to be more flexible should not cause any negative impact to other VMs now or in the future.

I have been using this feature for about a year (it was previously rejected prior to open-simh) and it has helped tremendously with software development under the AltairZ80 simulator. As the default behavior remains unchanged, this PR should have no impact on users that prefer the standard SCP stopped output.

It is also possible to add other custom stopped displays in addition to DDT-styled format.