### PR TITLE
AltairZ80: Add "MEM" and "REG" simulator-specific commands

### DIFF
--- a/AltairZ80/altairz80_cpu.c
+++ b/AltairZ80/altairz80_cpu.c
@@ -175,6 +175,8 @@ static uint32 GetBYTE(register uint32 Addr);
 static void PutWORD(register uint32 Addr, const register uint32 Value);
 static void PutBYTE(register uint32 Addr, const register uint32 Value);
 static const char* cpu_description(DEVICE *dptr);
+static t_stat cpu_cmd_memory(int32 flag, CONST char *cptr);
+static t_stat cpu_cmd_reg(int32 flag, CONST char *cptr);
 void out(const uint32 Port, const uint32 Value);
 uint32 in(const uint32 Port);
 void altairz80_init(void);
@@ -572,6 +574,13 @@ static MTAB cpu_mod[] = {
     { MTAB_XTD|MTAB_VDV|MTAB_NMO|MTAB_VALO|MTAB_SHP, 0, "HISTORY", "HISTORY",   &cpu_set_hist, &cpu_show_hist,
       NULL, "CPU instruction history buffer"},
     { 0 }
+};
+
+/* Simulator-specific commands */
+static CTAB cpu_cmd_tbl[] = {
+    { "MEM", &cpu_cmd_memory, 0, "MEM <address>    Dump a block of memory\n" },
+    { "REG", &cpu_cmd_reg,    0, "REG              Display registers\n" },
+    { NULL, NULL, 0, NULL }
 };
 
 /* Debug Flags */
@@ -6316,6 +6325,7 @@ static t_stat cpu_reset(DEVICE *dptr) {
     int32 i;
     if (sim_vm_is_subroutine_call == NULL) { /* First time reset? */
         sim_vm_is_subroutine_call = cpu_is_pc_a_subroutine_call;
+        sim_vm_cmd = cpu_cmd_tbl;
         altairz80_init();
     }
     AF_S = AF1_S = 0;
@@ -7230,3 +7240,110 @@ void cpu_raise_interrupt(uint32 irq) {
                (chiptype < NUM_CHIP_TYPE) ? cpu_mod[chiptype].mstring : "????");
     }
 }
+
+static t_addr disp_addr = 0;
+
+static t_stat cpu_cmd_memory(int32 flag, const char *cptr) {
+    const char *result;
+    char abuf[16];
+    t_addr lo, hi, last;
+    t_value byte;
+
+    if ((result = get_range(NULL, cptr, &lo, &hi, 16, MEMORYMASK, 0)) == NULL) {
+        lo = hi = disp_addr;
+    }
+    else {
+        disp_addr = lo & ~(0x0f);
+    }
+
+    if (hi == lo) {
+        hi = (lo & ~(0x0f)) + 0xff;
+    }
+
+    last = hi | 0x00000f;
+
+    while (disp_addr <= last && disp_addr <= MEMORYMASK) {
+
+        if (!(disp_addr & 0x0f)) {
+            if (MEMORYSIZE <= 0x10000) {
+                sim_printf("%04X ", disp_addr);
+            }
+            else {
+                sim_printf("%02X:%04X ", disp_addr >> 16, disp_addr & 0xffff);
+            }
+        }
+
+        if (disp_addr < lo || disp_addr > hi) {
+            sim_printf("   ");
+            abuf[disp_addr & 0x0f] = ' ';
+        }
+        else {
+            cpu_ex(&byte, disp_addr, &cpu_unit, 0);
+            sim_printf("%02X ", byte);
+            abuf[disp_addr & 0x0f] = sim_isprint(byte) ? byte : '.';
+        }
+
+        if ((disp_addr & 0x000f) == 0x000f) {
+            sim_printf("%16.16s\n", abuf);
+        }
+
+        disp_addr++;
+    }
+
+    if (disp_addr > MEMORYMASK) {
+        disp_addr = 0;
+    }
+
+    return SCPE_OK | SCPE_NOMESSAGE;
+}
+
+static t_stat cpu_cmd_reg(int32 flag, CONST char *cptr)
+{
+    t_value op[INST_MAX_BYTES];
+    int i;
+
+    if (chiptype != CHIP_TYPE_8080 && chiptype != CHIP_TYPE_Z80) {
+        sim_printf("REG requires 8080 or Z80 CPU\n");
+        return SCPE_NOFNC;
+    }
+
+    for (i = 0; i < INST_MAX_BYTES; i++) {
+        op[i] = GetBYTE(PC_S + i);
+    }
+
+    if (chiptype == CHIP_TYPE_8080) {
+        /*
+        ** Use DDT output:
+        ** CfZfMfEfIf A=bb B=dddd D=dddd H=dddd S=dddd P=dddd inst
+        */
+        sim_printf("C%dZ%dM%dE%dI%d A=%02X B=%04X D=%04X H=%04X S=%04X P=%04X ",
+            TSTFLAG2(AF_S, C),
+            TSTFLAG2(AF_S, Z),
+            TSTFLAG2(AF_S, S),
+            TSTFLAG2(AF_S, P),
+            TSTFLAG2(AF_S, H),
+            HIGH_REGISTER(AF_S), (uint16) BC_S, (uint16) DE_S, (uint16) HL_S, (uint16) SP_S, (uint16) PC_S);
+        fprint_sym (stdout, PC_S, op, &cpu_unit, SWMASK ('M'));
+    } else {    /* Z80 */
+        /*
+        ** Use DDT/Z output:
+        */
+        sim_printf("C%dZ%dS%dV%dH%dN%d A =%02X BC =%04X DE =%04X HL =%04X S =%04X P =%04X ",
+            TSTFLAG2(AF_S, C),
+            TSTFLAG2(AF_S, Z),
+            TSTFLAG2(AF_S, S),
+            TSTFLAG2(AF_S, P),
+            TSTFLAG2(AF_S, H),
+            TSTFLAG2(AF_S, N),
+            HIGH_REGISTER(AF_S), (uint16) BC_S, (uint16) DE_S, (uint16) HL_S, (uint16) SP_S, (uint16) PC_S);
+        fprint_sym (stdout, PC_S, op, &cpu_unit, SWMASK ('M'));
+        sim_printf("\n");
+        sim_printf("             A'=%02X BC'=%04X DE'=%04X HL'=%04X IX=%04X IY=%04X",
+            HIGH_REGISTER(AF1_S), (uint16) BC1_S, (uint16) DE1_S, (uint16) HL1_S, (uint16) IX_S, (uint16) IY_S);
+    }
+
+    sim_printf("\n");
+
+    return SCPE_OK | SCPE_NOMESSAGE;
+}
+

--- a/AltairZ80/altairz80_defs.h
+++ b/AltairZ80/altairz80_defs.h
@@ -40,6 +40,7 @@
 #define ADDRMASKEXTENDED        (MAXMEMORY - 1)             /* extended address mask                        */
 #define BANKMASK                (MAXBANKS - 1)              /* bank mask                                    */
 #define MEMORYSIZE              (cpu_unit.capac)            /* actual memory size                           */
+#define MEMORYMASK              (cpu_unit.capac - 1)        /* actual memory size mask                      */
 #define KB                      1024                        /* kilo byte                                    */
 #define KBLOG2                  10                          /* log2 of KB                                   */
 #define ALTAIR_ROM_LOW          0xff00                      /* start address of regular Altair ROM          */


### PR DESCRIPTION
```
sim> mem df00
DF00 C3 5C E2 C3 58 E2 7F 00 43 6F 70 79 72 69 67 68 .\..X...Copyrigh
DF10 74 20 31 39 37 39 20 28 63 29 20 62 79 20 44 69 t 1979 (c) by Di 
DF20 67 69 74 61 6C 20 52 65 73 65 61 72 63 68 20 20 gital Research
DF30 20 20 20 20 00 00 00 00 00 00 00 00 00 00 00 00     ............
DF40 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
DF50 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
DF60 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ....s...ub...m..
DF70 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ..I..tT...e.....
DF80 00 00 00 00 00 00 00 00 08 DF 00 00 5F 0E 02 C3 d....4...l.._0.r
DF90 05 00 C5 CD 8C DF C1 C9 3E 0D CD 92 DF 3E 0A C3 .d..M...>....>..
DFA0 92 DF 3E 20 C3 92 DF C5 CD 98 DF E1 7E B7 C8 23 ..> ..a.....~..#
DFB0 E5 CD 8C DF E1 C3 AC DF 0E 0D C3 05 00 5F 0E 0E ...r........._..
DFC0 C3 05 00 CD 05 00 32 EE E6 3C C9 0E 0F C3 C3 DF ...K..2..<..'.s.
DFD0 AF 32 ED E6 11 CD E6 C3 CB DF 0E 10 C3 C3 DF 0E .2...a...p.P....
DFE0 11 C3 C3 DF 0E 12 C3 C3 DF 11 CD E6 C3 DF DF 0E ...r...0..v.....
DFF0 13 C3 05 00 CD 05 00 B7 C9 0E 14 C3 F4 DF 11 CD .....a.l........
```

```
sim> reg
C0Z1M0E1I1 A=02 B=007F D=DF06 H=EA0E S=EA37 P=FA6B ANI 01h
sim> set on
sim> on error reg
sim> s

Step expired, PC: 0FA6D (JZ 0FA69h)
C0Z1M0E1I1 A=00 B=007F D=DF06 H=EA0E S=EA37 P=FA6D JZ 0FA69h
sim> s

Step expired, PC: 0FA69 (IN 10h)
C0Z1M0E1I1 A=00 B=007F D=DF06 H=EA0E S=EA37 P=FA69 IN 10h
sim> s

Step expired, PC: 0FA6B (ANI 01h)
C0Z1M0E1I1 A=02 B=007F D=DF06 H=EA0E S=EA37 P=FA6B ANI 01h
```

My apologies for the superfluous and redundant linefeed, PC, and instruction mnemonics causing unwanted separation in output; confusing the usage by treating an intended result as an "error"; and relying on a poorly documented and implemented SCP feature requiring reading the source code for specific "error" code usage. I tried.
