### PR TITLE
AltairZ80: Fix CPU_HALT stop code conflict with SCPE_OK and "ON 0"

### DIFF
--- a/AltairZ80/altairz80_defs.h
+++ b/AltairZ80/altairz80_defs.h
@@ -64,11 +64,11 @@ typedef enum {
 } ChipType;
 
 /* simulator stop codes */
-#define STOP_HALT       0   /* HALT                                             */
 #define STOP_IBKPT      1   /* breakpoint   (program counter)                   */
 #define STOP_MEM        2   /* breakpoint   (memory access)                     */
 #define STOP_INSTR      3   /* breakpoint   (instruction access)                */
 #define STOP_OPCODE     4   /* invalid operation encountered (8080, Z80, 8086)  */
+#define STOP_HALT       5   /* HALT                                             */
 
 #define UNIT_CPU_V_OPSTOP       (UNIT_V_UF+0)               /* stop on invalid operation                    */
 #define UNIT_CPU_OPSTOP         (1 << UNIT_CPU_V_OPSTOP)

--- a/AltairZ80/altairz80_sys.c
+++ b/AltairZ80/altairz80_sys.c
@@ -160,11 +160,12 @@ DEVICE      *sim_devices[]  = {
 static char memoryAccessMessage[256];
 static char instructionMessage[256];
 const char *sim_stop_messages[SCPE_BASE] = {
-    "HALT instruction",
+    "Unknown error",            /* 0 is reserved/unknown */
     "Breakpoint",
     memoryAccessMessage,
     instructionMessage,
-    "Invalid Opcode"
+    "Invalid Opcode",
+    "HALT instruction"
 };
 
 static const char *const Mnemonics8080[] = {

--- a/scp.c
+++ b/scp.c
@@ -9435,7 +9435,7 @@ t_value pcval;
 
 fputc ('\n', st);                                       /* start on a new line */
 
-if (v >= SCPE_BASE)                                     /* SCP error? */
+if (v == SCPE_OK || v >= SCPE_BASE)                                     /* SCP error? */
     fputs (sim_error_text (v), st);                     /* print it from the SCP list */
 else {                                                  /* VM error */
     if (sim_stop_messages [v])


### PR DESCRIPTION
AltairZ80 uses 0 for the VM-specific HLT instruction stop code.
SCP uses 0 to mean all errors ("ON ERROR").

The command "ON 0" will generate "%SIM-ERROR: Invalid argument: 0".

This PR changes the HALT stop code from 0 to 5.