### PR TITLE
SCELBI: Add missing array bound in sim_stop_messages array

### DIFF
--- a/Intel-Systems/scelbi/scelbi_sys.c
+++ b/Intel-Systems/scelbi/scelbi_sys.c
@@ -62,7 +62,7 @@ DEVICE *sim_devices[] = {
     NULL
 };
 
-const char *sim_stop_messages[] = {
+const char *sim_stop_messages[SCPE_BASE] = {
     "Unknown error",
     "Unknown I/O Instruction",
     "HALT instruction",


### PR DESCRIPTION
Somehow this simulator got missed when this change was made for all other simulators.