### PR TITLE
PDP9 VAX SEL32: Adjust test limits

### DIFF
--- a/PDP18B/tests/pdp9_test.ini
+++ b/PDP18B/tests/pdp9_test.ini
@@ -9,7 +9,7 @@ set cpu eae
 cd %~p0
 :: Limit maximum diagnostic execution time
 ::
-set runlimit 10M instructions
+set runlimit 40M instructions
 set on
 on error ignore
 on runtime echof "\r\n*** Test Runtime Limit %SIM_RUNLIMIT% %SIM_RUNLIMIT_UNITS% Exceeded ***\n"; exit 1

--- a/SEL32/tests/sel32_test.ini
+++ b/SEL32/tests/sel32_test.ini
@@ -22,8 +22,8 @@ set env HOST=sel32
 ; set env IP=192.168.1.5 (N/U)
 ;======================================================
 ;
-; Set run limit of 2 minutes
-set runlimit 750M instructions
+; Set run limit of 2 G instructions
+set runlimit 2000M instructions
 set on
 on error ignore
 on runtime echof "\r\n*** FAILED - SEL32 Test Runtime Limit %SIM_RUNLIMIT% %SIM_RUNLIMIT_UNITS% Exceeded ***\n"; exit 1

--- a/VAX/tests/vax-diag_test.ini
+++ b/VAX/tests/vax-diag_test.ini
@@ -125,7 +125,7 @@ expect "DS> " send "ATTACH KA820 HUB KA0 4096 0\r"; go -q
 expect "DS> " send "ATTACH DWBUA HUB DW0 4 5\r"; go -q
 # VAX 8200 simulates the floating point accelerator which then 
 # inspires tests to use it.  This takes more time.
-set runlimit 600M instructions   # Override prior runlimit
+set runlimit 2000M instructions
 call Common 
 call do_test EVKAB "VAX Basic Instructions Exerciser"
 call do_test EVKAC "VAX Floating Point Instructions Exerciser"


### PR DESCRIPTION
Adjust the instruction limits for three simulators so they pass on Apple M1 systems.