### PR TITLE
PDP11: Fix RK11/RL11 byte/word count mismatch (and cyl upd in RK11)

### DIFF
--- a/PDP11/pdp11_rk.c
+++ b/PDP11/pdp11_rk.c
@@ -574,7 +574,7 @@ if (wc && (err == 0)) {                                 /* seek ok? */
         else {                                          /* normal store */
             if ((t = MAP_WRW (ma, wc << 1, rkxb))) {    /* store buf */
                 rker = rker | RKER_NXM;                 /* NXM? set flag */
-                wc = wc - t;                            /* adj wd cnt */
+                wc = wc - (t >> 1);                     /* adj wd cnt */
                 }
             }
         break;                                          /* end read */
@@ -591,7 +591,7 @@ if (wc && (err == 0)) {                                 /* seek ok? */
         else {                                          /* normal fetch */
             if ((t = MAP_RDW (ma, wc << 1, rkxb))) {  /* get buf */
                 rker = rker | RKER_NXM;                 /* NXM? set flg */
-                wc = wc - t;                            /* adj wd cnt */
+                wc = wc - (t >> 1);                     /* adj wd cnt */
                 }
             }
         if (wc) {                                       /* any xfer? */
@@ -642,6 +642,7 @@ if ((uptr->FUNC == RKCS_READ) && (rkcs & RKCS_FMT))     /* read format? */
 else da = da + wc + (RK_NUMWD - 1);                     /* count by words */
 track = (da / RK_NUMWD) / RK_NUMSC;
 sect = (da / RK_NUMWD) % RK_NUMSC;
+uptr->CYL = track / RK_NUMSF;
 rkda = (rkda & RKDA_DRIVE) | (track << RKDA_V_TRACK) | (sect << RKDA_V_SECT);
 rk_set_done (0);
 

--- a/PDP11/pdp11_rl.c
+++ b/PDP11/pdp11_rl.c
@@ -866,7 +866,7 @@ if (DEBUG_PRS (rl_dev))
             rlxb[i] = 0;
         if ((t = Map_WriteW (ma, wc << 1, rlxb))) {     /* store buffer */
             rlcs = rlcs | RLCS_ERR | RLCS_NXM;          /* nxm */
-            wc = wc - t;                                /* adjust wc */
+            wc = wc - (t >> 1);                         /* adjust wc */
             }
         }                                               /* end read */
 
@@ -874,7 +874,7 @@ else
 if ((uptr->FNC == RLCS_WRITE) && (err == 0)) {          /* write? */
     if ((t = Map_ReadW (ma, wc << 1, rlxb))) {          /* fetch buffer */
         rlcs = rlcs | RLCS_ERR | RLCS_NXM;              /* nxm */
-        wc = wc - t;                                    /* adj xfer lnt */
+        wc = wc - (t >> 1);                             /* adj xfer lnt */
         }
     if (wc) {                                           /* any xfer? */
         awc = (wc + (RL_NUMWD - 1)) & ~(RL_NUMWD - 1);  /* clr to */


### PR DESCRIPTION
As discussed in PR129