### PR TITLE
3b2: Fix for clock drift when idling

### DIFF
--- a/3B2/3b2_stddev.c
+++ b/3B2/3b2_stddev.c
@@ -388,7 +388,6 @@ static t_stat tod_svc(UNIT *uptr)
     sim_activate_after(uptr, 1000000/CLK_TPS);
     tmr_poll = t;
     tmxr_poll = t;
-    AIO_SET_INTERRUPT_LATENCY(tmr_poll * CLK_TPS);
     return SCPE_OK;
 }
 

--- a/3B2/3b2_timer.c
+++ b/3B2/3b2_timer.c
@@ -345,8 +345,6 @@ uint32 timer_read(uint32 pa, size_t size)
            of also clearing pending interrupts */
         CSRBIT(CSRCLK, FALSE);
         CPU_CLR_INT(INT_CLOCK);
-        /* Acknowledge a clock tick */
-        sim_rtcn_tick_ack(1, TMR_CLK);
         retval = 0;
         break;
     default:


### PR DESCRIPTION
When the 3B2 simulator was set to allow idling, there was significant clock drift related to the primary timer unit. It turns out that the simulator was using `AIO_SET_INTERRUPT_LATENCY` and `sim_rtcn_tick_ack` incorrectly. They are not needed with the structure of system timers in the 3B2 architecture.