### PR TITLE
SCP: Refactor .git-commit-id.h out from sim_rev.h

### DIFF
--- a/HP3000/hp_tapelib.h
+++ b/HP3000/hp_tapelib.h
@@ -41,6 +41,7 @@
 
 
 
+#include "sim_rev.h"                        /* For SIM_MAJOR */
 #include "sim_tape.h"
 
 

--- a/I1620/i1620_defs.h
+++ b/I1620/i1620_defs.h
@@ -38,6 +38,7 @@
 #ifndef I1620_DEFS_H_
 #define I1620_DEFS_H_  0
 
+#include "sim_rev.h"
 #include "sim_defs.h"                                   /* simulator defns */
 
 #if defined(USE_INT64) || defined(USE_ADDR64)

--- a/scp.c
+++ b/scp.c
@@ -246,6 +246,10 @@
 #include <editline/readline.h>
 #endif
 
+#if defined(SIM_NEED_GIT_COMMIT_ID)
+#include ".git-commit-id.h"
+#endif
+
 #ifndef MAX
 #define MAX(a,b)  (((a) >= (b)) ? (a) : (b))
 #endif

--- a/sim_defs.h
+++ b/sim_defs.h
@@ -110,6 +110,7 @@
 #define SIM_DEFS_H_    0
 
 #include "sim_rev.h"
+
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/sim_rev.h
+++ b/sim_rev.h
@@ -44,17 +44,11 @@
 #define SIM_VERSION_MODE "Current"
 #endif
 
-#if defined(SIM_NEED_GIT_COMMIT_ID)
-#include ".git-commit-id.h"
-#endif
-
 /*
-  Simh's git commit id would be undefined when working with an 
-  extracted archive (zip file or tar ball).  To address this 
-  problem and record the commit id that the archive was created 
-  from, the archive creation process populates the below 
-  information as a consequence of the "sim_rev.h export-subst" 
-  line in the .gitattributes file.
+  SIM__GIT_COMMMIT_ID is undefined when working with an 
+  archive (zip file or tar ball).  Use Git keyword subsitution
+  to record the archive's commit id via the .gitattributes
+  "export-subst".
  */
 #define SIM_ARCHIVE_GIT_COMMIT_ID $Format:%H$
 #define SIM_ARCHIVE_GIT_COMMIT_TIME $Format:%aI$


### PR DESCRIPTION
Move simulator version info (SIM_MAJOR, _MINOR, _PATCH, _DELTA) to sim_defs.h; only include .git-commit-id.h in scp.c (only usage point.)

Reduce recompiled source to a minimum when .git-commit-id.h is updated and removes the sim_defs.h > sim_rev.h > .git-commit-id.h compile dependency subgraph. Everything includes sim_defs.h, so a change to .git-commit-id.h causes a large recompile, vice what should just be a scp.c recompile and simulator suite relink.

Does not impact makefile builds, since makefile builds will recompile everything; compile dependency tracking is superfluous.

Improves recompile times for future build systems that exploit compile dependencies more efficiently, when those build systems are adopted or accepted. In particular, CMake potentially updates .git-commit-id.h at compile time because CMake intentionally cannot change compiler flag values at compile time in a build-system-neutral manner. Consequently, the sim_defs.h > sim_rev.h > .git-commit-id.h dependency subgraph causes a lot of wasted recompiles.