### PR TITLE
Fix operand order bugs in PDP-11 FP11 disassembly

### DIFF
--- a/PDP11/pdp11_sys.c
+++ b/PDP11/pdp11_sys.c
@@ -342,6 +342,9 @@ return SCPE_CSUM;
 #define I_V_CCC         14                              /* CC clear */
 #define I_V_CCS         15                              /* CC set */
 #define I_V_SOPR        16                              /* operand, reg */
+#define I_V_FOPA        17                              /* flt operand, fac */
+#define I_V_SOPA        18                              /* operand, fac */
+#define I_V_SMDA        19                              /* moded int op, fac */
 #define I_NPN           (I_V_NPN << I_V_CL)
 #define I_REG           (I_V_REG << I_V_CL)
 #define I_3B            (I_V_3B << I_V_CL)
@@ -359,13 +362,16 @@ return SCPE_CSUM;
 #define I_CCC           (I_V_CCC << I_V_CL)
 #define I_CCS           (I_V_CCS << I_V_CL)
 #define I_SOPR          (I_V_SOPR << I_V_CL)
+#define I_FOPA          (I_V_FOPA << I_V_CL)
+#define I_SOPA          (I_V_SOPA << I_V_CL)
+#define I_SMDA          (I_V_SMDA << I_V_CL)
 
 static const int32 masks[] = {
 0177777, 0177770, 0177700, 0177770,
 0177700+I_D, 0177400+I_D, 0177700, 0177400,
 0177400, 0177000, 0177000, 0177400,
 0177400+I_D+I_L, 0170000, 0177777, 0177777,
-0177000
+0177000, 0177400+I_D, 0177400, 0177400+I_D+I_L
 };
 
 static const char *opcode[] = {
@@ -493,16 +499,16 @@ static const int32 opc_val[] = {
 0170100+I_SOP, 0170200+I_SOP, 0170300+I_SOP,
 0170400+I_FOP, 0170400+I_FOP+I_D, 0170500+I_FOP, 0170500+I_FOP+I_D,
 0170600+I_FOP, 0170600+I_FOP+I_D, 0170700+I_FOP, 0170700+I_FOP+I_D,
-0171000+I_AFOP, 0171000+I_AFOP+I_D, 0171400+I_AFOP, 0171400+I_AFOP+I_D,
-0172000+I_AFOP, 0172000+I_AFOP+I_D, 0172400+I_AFOP, 0172400+I_AFOP+I_D, 
-0173000+I_AFOP, 0173000+I_AFOP+I_D, 0173400+I_AFOP, 0173400+I_AFOP+I_D,
-0174000+I_AFOP, 0174000+I_AFOP+I_D, 0174400+I_AFOP, 0174400+I_AFOP+I_D,
+0171000+I_FOPA, 0171000+I_FOPA+I_D, 0171400+I_FOPA, 0171400+I_FOPA+I_D,
+0172000+I_FOPA, 0172000+I_FOPA+I_D, 0172400+I_FOPA, 0172400+I_FOPA+I_D, 
+0173000+I_FOPA, 0173000+I_FOPA+I_D, 0173400+I_FOPA, 0173400+I_FOPA+I_D,
+0174000+I_AFOP, 0174000+I_AFOP+I_D, 0174400+I_FOPA, 0174400+I_FOPA+I_D,
 0175000+I_ASOP,
 0175400+I_ASMD, 0175400+I_ASMD+I_D, 0175400+I_ASMD+I_L, 0175400+I_ASMD+I_D+I_L, 
 0176000+I_AFOP, 0176000+I_AFOP+I_D,
-0176400+I_ASOP, 
-0177000+I_ASMD, 0177000+I_ASMD+I_D, 0177000+I_ASMD+I_L, 0177000+I_ASMD+I_D+I_L, 
-0177400+I_AFOP, 0177400+I_AFOP+I_D,
+0176400+I_SOPA, 
+0177000+I_SMDA, 0177000+I_SMDA+I_D, 0177000+I_SMDA+I_L, 0177000+I_SMDA+I_D+I_L, 
+0177400+I_FOPA, 0177400+I_FOPA+I_D,
 -1
 };
 
@@ -694,6 +700,12 @@ for (i = 0; opc_val[i] >= 0; i++) {                     /* loop thru ops */
             wd1 = fprint_spec (of, addr, dstm, val[1], cflag, FALSE);
             break;
 
+        case I_V_FOPA:                                  /* fopa */
+            fprintf (of, "%s ", opcode[i]);
+            wd1 = fprint_spec (of, addr, dstm, val[1], cflag, FALSE);
+            fprintf (of, ",%s", fname[fac]);
+            break;
+
         case I_V_6B:                                    /* 6b */
             fprintf (of, "%s %-o", opcode[i], dstm);
             break;
@@ -736,6 +748,12 @@ for (i = 0; opc_val[i] >= 0; i++) {                     /* loop thru ops */
         case I_V_ASOP: case I_V_ASMD:                   /* asop, asmd */
             fprintf (of, "%s %s,", opcode[i], fname[fac]);
             wd1 = fprint_spec (of, addr, dstm, val[1], cflag, TRUE);
+            break;
+
+        case I_V_SOPA: case I_V_SMDA:                   /* sopa, smda */
+            fprintf (of, "%s ", opcode[i]);
+            wd1 = fprint_spec (of, addr, dstm, val[1], cflag, TRUE);
+            fprintf (of, ",%s", fname[fac]);
             break;
 
         case I_V_DOP:                                   /* dop */


### PR DESCRIPTION
### Issue

I was using the SIMH PDP-11 disassembler for some fuzzing tests in another project... and I discovered a disassembly issue. Instructions like `addf 001234,f0` are incorrectly being disassembled with the operands swapped, thus `addf f0,001234`.

### Fix

This PR fixes the issue, according to the reference I used which is at: 
  https://archive.org/details/bitsavers_decpdp11haorHandbook1981_37639914

Basically all of the 2-operand floating point instructions such as `modf`, `addf`, etc get their operands swapped in the disassembly printout but otherwise should work as before, *except* storage instructions like `stf`, `std`, `stexp`, `stcfi` etc which I have not changed.