### PR TITLE
AltairZ80: Add NMI interrupt support

### DIFF
--- a/AltairZ80/altairz80_cpu.c
+++ b/AltairZ80/altairz80_cpu.c
@@ -484,7 +484,7 @@ REG cpu_reg[] = {
     }, /* 82 */
     { HRDATAD(COMMONLOW,common_low,         1, "If set, use low memory for common area"),
     }, /* 83 */
-    { HRDATAD(VECINT,vectorInterrupt,       2, "Vector Interrupt pseudo register"),
+    { HRDATAD(VECINT,vectorInterrupt,       8, "Vector Interrupt pseudo register"),
     }, /* 84 */
     { BRDATAD (DATABUS, dataBus, 16, 8,     MAX_INT_VECTORS, "Data bus pseudo register"),
         REG_RO + REG_CIRC   }, /* 85 */

--- a/AltairZ80/s100_2sio.c
+++ b/AltairZ80/s100_2sio.c
@@ -546,6 +546,10 @@ static t_stat m2sio_detach(UNIT *uptr)
 {
     M2SIO_CTX *xptr;
 
+    if (uptr->dptr == NULL) {
+        return SCPE_IERR;
+    }
+
     sim_debug(VERBOSE_MSG, uptr->dptr, "detach.\n");
 
     if (uptr->flags & UNIT_ATT) {


### PR DESCRIPTION
Summary of changes:
- AltairZ80 CPU: Add support for NMI interrupts. Reference for [Z80 NMI behavior](http://www.z80.info/zip/z80-documented.pdf).
- Fix potential NULL pointer deference in s100_2sio.
- Fix width of vectorInterrupt pseudo register.

Compiled with:
- VS 2022 17.4.4 (Debug and Release)
- VS 2008 (Debug and Release)
- MacOS (x64) clang-1400.0.29.202
- Linux gcc 10.2.1

Automated tests: SIMH running on Windows, Linux (ARM), MacOS (x64):
- [CompuPro CP/M-80](https://schorn.ch/cpm/zip/cpm86.zip)
- [CompuPro CP/M-86](https://schorn.ch/cpm/zip/cpm86.zip)
- [SCP 86-DOS](https://schorn.ch/cpm/zip/86dos.zip)
- [MS-DOS 2.11](https://github.com/hharte/altairz80-packages/tree/main/msdos211_test)
- [CompuPro CP/M-68K v1.3](https://github.com/hharte/altairz80-packages/tree/main/ccpm68k13) (68000 and 68010 versions)
- [CP/M-68K v1.2](https://schorn.ch/cpm/zip/cpm68k.zip)
- [Advanced Digital Super-Six CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm2)
- [Advanced Digital Super-Six CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm3)
- [DIGITEX CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm2)
- [DIGITEX CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm3)
- [DIGITEX OASIS multi-user version 5.6](github.com/hharte/altairz80-packages/tree/main/dig_oasis56)
- [CP/M-80 (Altair)](https://schorn.ch/cpm/zip/cpm2.zip) ZEXALL Z80 instruction set test.

FYI, @psco , @deltecent 