### PR TITLE
Identify Open SIMH builds in version strings

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -6623,7 +6623,7 @@ sprintf (vmin_s, "%d", vmin);
 setenv ("SIM_MINOR", vmin_s, 1);
 sprintf (vpat_s, "%d", vpat);
 setenv ("SIM_PATCH", vpat_s, 1);
-fprintf (st, "%s simulator V%d.%d-%d", sim_name, vmaj, vmin, vpat);
+fprintf (st, "%s simulator Open SIMH V%d.%d-%d", sim_name, vmaj, vmin, vpat);
 if (sim_vm_release != NULL) {                           /* if a release string is defined */
     setenv ("SIM_VM_RELEASE", sim_vm_release, 1);
     fprintf (st, " Release %s", sim_vm_release);        /*   then display it */

--- a/sim_rev.h
+++ b/sim_rev.h
@@ -31,7 +31,7 @@
 #define SIM_MAJOR       4
 #endif
 #ifndef SIM_MINOR
-#define SIM_MINOR       0
+#define SIM_MINOR       1
 #endif
 #ifndef SIM_PATCH
 #define SIM_PATCH       0


### PR DESCRIPTION
With three simulators sharing a common heritage and name, it can get confusing when questions arise from the user community.

This edit changes the Minor version from 0 to 1 (e.g. V4.1) and adds "Open SIMH" to the banner and show version output.

