### PR TITLE
AltairZ80, sim_imd: Fix static code analysis warnings.

### DIFF
--- a/AltairZ80/altairz80_cpu.c
+++ b/AltairZ80/altairz80_cpu.c
@@ -6628,7 +6628,7 @@ static const char* m68kVariantToString[] = {
 
 static t_stat chip_show(FILE *st, UNIT *uptr, int32 val, CONST void *desc) {
     fprintf(st, cpu_unit.flags & UNIT_CPU_OPSTOP ? "ITRAP, " : "NOITRAP, ");
-    if (chiptype < NUM_CHIP_TYPE) {
+    if ((chiptype >= 0) && (chiptype < NUM_CHIP_TYPE)) {
         fprintf(st, "%s", cpu_mod[chiptype].mstring);
         if (chiptype == CHIP_TYPE_M68K) {
             fprintf(st, " (%s)", m68kVariantToString[m68kvariant]);
@@ -6677,7 +6677,7 @@ static t_stat cpu_show(FILE *st, UNIT *uptr, int32 val, CONST void *desc) {
             }
         fprintf(st, "]");
     }
-    if (chiptype < NUM_CHIP_TYPE) {
+    if ((chiptype >= 0) && (chiptype < NUM_CHIP_TYPE)) {
         first = TRUE;
         /* show verbose CPU flags */
         for (i = 0; cpuflags[chiptype][i].mask; i++)
@@ -6861,7 +6861,7 @@ static int32 bankseldev(const int32 port, const int32 io, const int32 data) {
 }
 
 static void cpu_set_chiptype_short(const int32 value) {
-    if ((chiptype == value) || (chiptype >= NUM_CHIP_TYPE))
+    if ((chiptype == value) || (value < 0) || (value >= NUM_CHIP_TYPE))
         return; /* nothing to do */
     if (((chiptype == CHIP_TYPE_8080) && (value == CHIP_TYPE_Z80)) ||
         ((chiptype == CHIP_TYPE_Z80) && (value == CHIP_TYPE_8080))) {
@@ -7090,7 +7090,7 @@ static t_stat cpu_set_hist(UNIT *uptr, int32 val, CONST char *cptr, void *desc) 
    uint32 i, lnt;
    t_stat r;
 
-    if ((chiptype != CHIP_TYPE_8080) && (chiptype != CHIP_TYPE_Z80)) {
+    if ((chiptype >= 0) && (chiptype != CHIP_TYPE_8080) && (chiptype != CHIP_TYPE_Z80)) {
         sim_printf("History not supported for chiptype: %s\n",
                (chiptype < NUM_CHIP_TYPE) ? cpu_mod[chiptype].mstring : "????");
         return SCPE_NOFNC;
@@ -7158,7 +7158,8 @@ t_stat cpu_show_hist (FILE *st, UNIT *uptr, int32 val, CONST void *desc)
 
     if ((chiptype != CHIP_TYPE_8080) && (chiptype != CHIP_TYPE_Z80)) {
         sim_printf("History not supported for chiptype: %s\n",
-               (chiptype < NUM_CHIP_TYPE) ? cpu_mod[chiptype].mstring : "????");
+            (0 <= chiptype) && (chiptype < NUM_CHIP_TYPE) ?
+            cpu_mod[chiptype].mstring : "????");
         return SCPE_NOFNC;
     }
 
@@ -7377,6 +7378,9 @@ static t_stat cpu_hex_load(FILE *fileref, CONST char *cptr, CONST char *fnam, in
 
         bufptr = datastr;
 
+        /* Ensure datastr is NULL-terminated. */
+        datastr[sizeof(datastr) - 1] = '\0';
+
         if ((rectype == 0) && (bytecnt > 0) && (addr+bytecnt <= MAXMEMORY)) {
             if (cnt == 0)
                 org = addr;
@@ -7413,7 +7417,8 @@ void cpu_raise_interrupt(uint32 irq) {
         cpu8086_intr(irq);
     } else if (cpu_unit.flags & UNIT_CPU_VERBOSE) {
         sim_printf("Interrupts not fully supported for chiptype: %s\n",
-               (chiptype < NUM_CHIP_TYPE) ? cpu_mod[chiptype].mstring : "????");
+            (0 <= chiptype) && (chiptype < NUM_CHIP_TYPE) ?
+            cpu_mod[chiptype].mstring : "????");
     }
 }
 

--- a/AltairZ80/altairz80_cpu.c
+++ b/AltairZ80/altairz80_cpu.c
@@ -6412,7 +6412,7 @@ static t_stat cpu_reset(DEVICE *dptr) {
     AF_S = AF1_S = 0;
     BC_S = DE_S = HL_S = 0;
     BC1_S = DE1_S = HL1_S = 0;
-    IR_S = IX_S = IY_S = SP_S = 0;
+    IR_S = IX_S = IY_S = SP_S = PC_S = 0;
     IM_S = IFF_S = 0;  /* Set IM0, reset IFF1 and IFF2 */
     setBankSelect(0);
     cpu8086reset();

--- a/AltairZ80/altairz80_hdsk.c
+++ b/AltairZ80/altairz80_hdsk.c
@@ -692,6 +692,9 @@ static t_stat set_format(UNIT *uptr, int32 val, CONST char *cptr, void *desc) {
         sim_printf("Cannot set format for not attached unit %i.\n", find_unit_index(uptr));
         return SCPE_ARG;
     }
+
+    fmtname[DPB_NAME_LENGTH] = '\0';
+
     for (i = 0; dpb[i].capac != 0; i++) {
         if (strncmp(fmtname, dpb[i].name, strlen(fmtname)) == 0) {
             uptr -> HDSK_FORMAT_TYPE = i;

--- a/AltairZ80/altairz80_sio.c
+++ b/AltairZ80/altairz80_sio.c
@@ -57,18 +57,9 @@
 
 uint8 *URLContents(const char *URL, uint32 *length);
 #ifndef URL_READER_SUPPORT
-#define RESULT_BUFFER_LENGTH    1024
-#define RESULT_LEAD_IN          "URL is not supported on this platform. START URL \""
-#define RESULT_LEAD_OUT         "\" URL END."
 uint8 *URLContents(const char *URL, uint32 *length) {
-    char str[RESULT_BUFFER_LENGTH] = RESULT_LEAD_IN;
-    char *result;
-    strncat(str, URL, RESULT_BUFFER_LENGTH - strlen(RESULT_LEAD_IN) - strlen(RESULT_LEAD_OUT) - 1);
-    strcat(str, RESULT_LEAD_OUT);
-    result = (char*)malloc(strlen(str) + 1);
-    strcpy(result, str);
-    *length = strlen(str);
-    return (uint8*)result;
+    *length = 0;
+    return (uint8*)NULL;
 }
 #endif
 
@@ -279,9 +270,11 @@ static void processDirEntry (const char *directory,
                              void *context) {
     if (filename != NULL) {
         NameNode_t *top = (NameNode_t *)malloc(sizeof(NameNode_t));
-        top -> name = strdup(filename);
-        top -> next = nameListHead;
-        nameListHead = top;
+        if (top) {
+            top->name = strdup(filename);
+            top->next = nameListHead;
+            nameListHead = top;
+        }
     }
 }
 

--- a/AltairZ80/altairz80_sys.c
+++ b/AltairZ80/altairz80_sys.c
@@ -952,3 +952,19 @@ t_stat show_iobase(FILE *st, UNIT *uptr, int32 val, CONST void *desc)
     return SCPE_OK;
 }
 
+/* find_unit_index   find index of a unit
+
+   Inputs:
+        uptr    =       pointer to unit
+   Outputs:
+        result  =       index of device
+*/
+int32 find_unit_index(UNIT* uptr)
+{
+    DEVICE *dptr = find_dev_from_unit(uptr);
+
+    if (dptr == NULL)
+        return -1;
+
+    return (uptr - dptr->units);
+}

--- a/AltairZ80/flashwriter2.c
+++ b/AltairZ80/flashwriter2.c
@@ -1,6 +1,6 @@
 /*************************************************************************
  *                                                                       *
- * Copyright (c) 2007-2022 Howard M. Harte.                              *
+ * Copyright (c) 2007-2023 Howard M. Harte.                              *
  * https://github.com/hharte                                             *
  *                                                                       *
  * Permission is hereby granted, free of charge, to any person obtaining *
@@ -138,6 +138,11 @@ static t_stat fw2_attach(UNIT *uptr, CONST char *cptr)
     }
 
     fw2_info[i] = (FW2_INFO *)calloc(1, sizeof(FW2_INFO));
+
+    if (fw2_info[i] == NULL) {
+        return SCPE_MEM;
+    }
+
     fw2_info[i]->uptr = uptr;
     fw2_info[i]->uptr->u3 = baseaddr;
 
@@ -200,7 +205,9 @@ static t_stat fw2_detach(UNIT *uptr)
 static t_stat get_base_address(const char *cptr, uint32 *baseaddr)
 {
     uint32 b;
-    sscanf(cptr, "%x", &b);
+
+    if (sscanf(cptr, "%x", &b) != 1) return SCPE_ARG;
+
     if(b & (FW2_CAPACITY-1)) {
         sim_printf("FWII must be on a %d-byte boundary.\n", FW2_CAPACITY);
         return SCPE_ARG;

--- a/AltairZ80/i8272.c
+++ b/AltairZ80/i8272.c
@@ -129,6 +129,7 @@ extern t_stat set_iobase(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 extern t_stat show_iobase(FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 extern uint32 sim_map_resource(uint32 baseaddr, uint32 size, uint32 resource_type,
                                int32 (*routine)(const int32, const int32, const int32), const char* name, uint8 unmap);
+extern int32 find_unit_index(UNIT* uptr);
 
 /* These are needed for DMA.  PIO Mode has not been implemented yet. */
 extern void PutByteDMA(const uint32 Addr, const uint32 Value);
@@ -166,7 +167,6 @@ extern uint8 GetByteDMA(const uint32 Addr);
 static void raise_i8272_interrupt(void);
 static int32 i8272dev(const int32 port, const int32 io, const int32 data);
 static t_stat i8272_reset(DEVICE *dptr);
-int32 find_unit_index (UNIT *uptr);
 static const char* i8272_description(DEVICE *dptr);
 
 I8272_INFO i8272_info_data = { { 0x0, 0, 0xC0, 2 } };
@@ -242,32 +242,6 @@ static t_stat i8272_reset(DEVICE *dptr)
     return SCPE_OK;
 }
 
-
-/* find_unit_index   find index of a unit
-
-   Inputs:
-        uptr    =       pointer to unit
-   Outputs:
-        result  =       index of device
-*/
-int32 find_unit_index (UNIT *uptr)
-{
-    DEVICE *dptr;
-    uint32 i;
-
-    if (uptr == NULL)
-        return (-1);
-    dptr = find_dev_from_unit(uptr);
-    for(i=0; i<dptr->numunits; i++) {
-        if(dptr->units + i == uptr) {
-            break;
-        }
-    }
-    if(i == dptr->numunits) {
-        return (-1);
-    }
-    return (i);
-}
 
 /* Attach routine */
 t_stat i8272_attach(UNIT *uptr, CONST char *cptr)

--- a/AltairZ80/m68k/m68kfpu.c
+++ b/AltairZ80/m68k/m68kfpu.c
@@ -1,8 +1,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdarg.h>
-
-extern void exit(int);
+#include <stdlib.h>
 
 static void fatalerror(const char *format, ...) {
       va_list ap;
@@ -128,7 +127,9 @@ static inline floatx80 load_pack_float80(uint32 ea)
     *ch++ = (char)(((dw1 >> 16) & 0xf) + '0');
     *ch = '\0';
 
-    sscanf(str, "%le", &tmp);
+    if (sscanf(str, "%le", &tmp) == 1) {
+        result = double_to_fx80(tmp);
+    }
 
     result = double_to_fx80(tmp);
 
@@ -596,7 +597,7 @@ static uint64 READ_EA_64(int ea)
 
 static floatx80 READ_EA_FPE(int mode, int reg, uint32 di_mode_ea)
 {
-    floatx80 fpr;
+    floatx80 fpr = { 0 };
 
     switch (mode)
     {
@@ -659,7 +660,7 @@ static floatx80 READ_EA_FPE(int mode, int reg, uint32 di_mode_ea)
 
 static floatx80 READ_EA_PACK(int ea)
 {
-    floatx80 fpr;
+    floatx80 fpr = { 0 };
     int mode = (ea >> 3) & 0x7;
     int reg = (ea & 0x7);
 
@@ -1052,7 +1053,7 @@ static void fpgen_rm_reg(uint16 w2)
     int src = (w2 >> 10) & 0x7;
     int dst = (w2 >>  7) & 0x7;
     int opmode = w2 & 0x7f;
-    floatx80 source;
+    floatx80 source = { 0 };
 
     // fmovecr #$f, fp0 f200 5c0f
 

--- a/AltairZ80/s100_disk3.c
+++ b/AltairZ80/s100_disk3.c
@@ -1,6 +1,6 @@
 /*************************************************************************
  *                                                                       *
- * Copyright (c) 2007-2022 Howard M. Harte.                              *
+ * Copyright (c) 2007-2023 Howard M. Harte.                              *
  * https://github.com/hharte                                             *
  *                                                                       *
  * Permission is hereby granted, free of charge, to any person obtaining *
@@ -537,6 +537,11 @@ static uint8 DISK3_Write(const uint32 Addr, uint8 cData)
 
                 dataBuffer = (uint8 *)malloc(xfr_len);
 
+                if (dataBuffer == NULL) {
+                    sim_printf("%s: memory allocation failure.\n", sim_uname(pDrive->uptr));
+                    break;
+                }
+
                 if(sim_fseek((pDrive->uptr)->fileref, file_offset, SEEK_SET) == 0) {
 
                     if(disk3_info->iopb[DISK3_IOPB_ARG1] == 1) { /* Read */
@@ -615,6 +620,12 @@ static uint8 DISK3_Write(const uint32 Addr, uint8 cData)
                 file_offset += (disk3_info->iopb[DISK3_IOPB_ARG3] * data_len);
 
                 fmtBuffer = (uint8 *)malloc(data_len);
+
+                if (fmtBuffer == NULL) {
+                    sim_printf("%s: memory allocation failure.\n", sim_uname(pDrive->uptr));
+                    break;
+                }
+
                 memset(fmtBuffer, disk3_info->iopb[DISK3_IOPB_ARG2], data_len);
 
                 if(sim_fseek((pDrive->uptr)->fileref, file_offset, SEEK_SET) == 0) {

--- a/AltairZ80/wd179x.c
+++ b/AltairZ80/wd179x.c
@@ -570,7 +570,6 @@ uint8 WD179X_Read(const uint32 Addr)
     WD179X_DRIVE_INFO    *pDrive;
     uint32 flags = 0;
     uint32 readlen;
-    int status = SCPE_OK;
 
     if (wd179x_info->sel_drive >= WD179X_MAX_DRIVES) {
         return 0xFF;
@@ -651,14 +650,14 @@ uint8 WD179X_Read(const uint32 Addr)
                             if (pDrive->uptr->fileref == NULL) {
                                 sim_printf(".fileref is NULL!\n");
                             } else {
-                                status = wd179x_sectRead(pDrive,
-                                pDrive->track,
-                                wd179x_info->fdc_head,
-                                wd179x_info->fdc_sector,
-                                sdata.raw,
-                                WD179X_SECTOR_LEN_BYTES,
-                                &flags,
-                                &readlen);
+                                wd179x_sectRead(pDrive,
+                                    pDrive->track,
+                                    wd179x_info->fdc_head,
+                                    wd179x_info->fdc_sector,
+                                    sdata.raw,
+                                    WD179X_SECTOR_LEN_BYTES,
+                                    &flags,
+                                    &readlen);
                             }
                         }
                     }
@@ -878,7 +877,6 @@ static uint8 Do1793Command(uint8 cCommand)
     WD179X_DRIVE_INFO    *pDrive;
     uint32 flags = 0;
     uint32 readlen;
-    int status;
 
     if (wd179x_info->sel_drive >= WD179X_MAX_DRIVES) {
         return 0xFF;
@@ -1040,7 +1038,7 @@ static uint8 Do1793Command(uint8 cCommand)
                 wd179x_info->intrq = 1;
                 wd179x_info->drq = 0;
             } else {
-                status = wd179x_sectRead(pDrive,
+                wd179x_sectRead(pDrive,
                     pDrive->track,
                     wd179x_info->fdc_head,
                     wd179x_info->fdc_sector,
@@ -1400,7 +1398,7 @@ static t_stat wd179x_sectWrite(WD179X_DRIVE_INFO* pDrive,
             break;
     }
 
-    return (SCPE_OK);
+    return (status);
 }
 
 static t_stat wd179x_trackWrite(WD179X_DRIVE_INFO* pDrive,
@@ -1471,6 +1469,6 @@ static t_stat wd179x_trackWrite(WD179X_DRIVE_INFO* pDrive,
         }
     }
 
-    return(SCPE_OK);
+    return(status);
 }
 

--- a/Visual Studio Projects/AltairZ80.vcxproj
+++ b/Visual Studio Projects/AltairZ80.vcxproj
@@ -87,12 +87,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Message>Check for required build dependencies &amp; git commit id</Message>
-      <Command>Pre-Build-Event.cmd "$(TargetDir)$(TargetName).exe" LIBPCRE</Command>
+      <Command>Pre-Build-Event.cmd "$(TargetDir)$(TargetName).exe" LIBPCRE LIBSDL</Command>
     </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../AltairZ80/;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/include;../../windows-build/include/SDL2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>inline=__inline;SIM_BUILD_TOOL=simh-Visual-Studio-Project;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCRE_H;PCRE_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;SIM_BUILD_TOOL=simh-Visual-Studio-Project;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCRE_H;PCRE_STATIC;USE_SIM_VIDEO;HAVE_LIBSDL;HAVE_LIBPNG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessKeepComments>false</PreprocessKeepComments>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -122,12 +122,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <PreBuildEvent>
       <Message>Check for required build dependencies &amp; git commit id</Message>
-      <Command>Pre-Build-Event.cmd "$(TargetDir)$(TargetName).exe" LIBPCRE</Command>
+      <Command>Pre-Build-Event.cmd "$(TargetDir)$(TargetName).exe" LIBPCRE LIBSDL</Command>
     </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../AltairZ80/;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/include;../../windows-build/include/SDL2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>inline=__inline;SIM_BUILD_TOOL=simh-Visual-Studio-Project;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCRE_H;PCRE_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;SIM_BUILD_TOOL=simh-Visual-Studio-Project;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCRE_H;PCRE_STATIC;USE_SIM_VIDEO;HAVE_LIBSDL;HAVE_LIBPNG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessKeepComments>false</PreprocessKeepComments>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -287,6 +287,8 @@
     <ClCompile Include="..\AltairZ80\s100_ss1.c" />
     <ClCompile Include="..\AltairZ80\s100_tarbell.c" />
     <ClCompile Include="..\AltairZ80\s100_tdd.c" />
+    <ClCompile Include="..\AltairZ80\s100_vdm1.c" />
+    <ClCompile Include="..\AltairZ80\sol20.c" />
     <ClCompile Include="..\AltairZ80\vfdhd.c" />
     <ClCompile Include="..\AltairZ80\wd179x.c" />
     <ClCompile Include="..\scp.c" />

--- a/Visual Studio Projects/AltairZ80.vcxproj.filters
+++ b/Visual Studio Projects/AltairZ80.vcxproj.filters
@@ -207,6 +207,12 @@
     <ClCompile Include="..\AltairZ80\wd179x.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\AltairZ80\s100_vdm1.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\AltairZ80\sol20.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\AltairZ80\altairz80_defs.h">

--- a/sim_imd.c
+++ b/sim_imd.c
@@ -1,6 +1,6 @@
 /*************************************************************************
  *                                                                       *
- * Copyright (c) 2007-2022 Howard M. Harte.                              *
+ * Copyright (c) 2007-2023 Howard M. Harte.                              *
  * https://github.com/hharte                                             *
  *                                                                       *
  * Permission is hereby granted, free of charge, to any person obtaining *
@@ -55,7 +55,12 @@ DISK_INFO *diskOpenEx(FILE *fileref, uint32 isVerbose, DEVICE *device, uint32 de
 {
     DISK_INFO *myDisk = NULL;
 
-    myDisk = (DISK_INFO *)malloc(sizeof(DISK_INFO));
+    myDisk = (DISK_INFO*)calloc(1, sizeof(DISK_INFO));
+    if (myDisk == NULL) {
+        sim_printf("%s: %s(): memory allocation failure.\n", __FILE__, __FUNCTION__);
+        return NULL;
+    }
+
     myDisk->file = fileref;
     myDisk->device = device;
     myDisk->debugmask = debugmask;
@@ -765,6 +770,12 @@ t_stat trackWrite(DISK_INFO *myDisk,
      */
     dataLen = sectorLen + 1;
     sectorData = (uint8 *)malloc(dataLen);
+
+    if (sectorData == NULL) {
+        sim_printf("%s: %s(): memory allocation failure.\n", __FILE__, __FUNCTION__);
+        return SCPE_MEM;
+    }
+
     memset(sectorData, fillbyte, dataLen);
     sectorData[0] = SECT_RECORD_NORM;
 


### PR DESCRIPTION
Summary of changes:

* Fix static code analysis issues in sim_imd.c.
* Fix static code analysis issues in Flashwriter and CompuPro Disk3.

Compiled with:

VS 2022 17.5.3 (Debug and Release)
VS 2008 (Debug and Release)
MacOS (x64) clang-1400.0.29.202
Linux gcc 10.2.1
Automated tests: SIMH running on Windows, Linux (ARM), MacOS (x64):

[CompuPro CP/M-80](https://schorn.ch/cpm/zip/cpm86.zip)
[CompuPro CP/M-86](https://schorn.ch/cpm/zip/cpm86.zip)
[SCP 86-DOS](https://schorn.ch/cpm/zip/86dos.zip)
[MS-DOS 2.11](https://github.com/hharte/altairz80-packages/tree/main/msdos211_test)
[CompuPro CP/M-68K v1.3](https://github.com/hharte/altairz80-packages/tree/main/ccpm68k13) (68000 and 68010 versions)
[CP/M-68K v1.2](https://schorn.ch/cpm/zip/cpm68k.zip)
[Advanced Digital Super-Six CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm2)
[Advanced Digital Super-Six CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm3)
[DIGITEX CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm2)
[DIGITEX CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm3)
[DIGITEX OASIS multi-user version 5.6](https://github.com/open-simh/simh/pull/github.com/hharte/altairz80-packages/tree/main/dig_oasis56)
[CP/M-80 (Altair)](https://schorn.ch/cpm/zip/cpm2.zip) ZEXALL Z80 instruction set test.

FYI, @psco , @markpizz 