### PR TITLE
AltairZ80: ADCS6: Fix uninitialized unit structure

### DIFF
--- a/AltairZ80/s100_adcs6.c
+++ b/AltairZ80/s100_adcs6.c
@@ -1,6 +1,6 @@
 /*************************************************************************
  *                                                                       *
- * Copyright (c) 2007-2022 Howard M. Harte.                              *
+ * Copyright (c) 2007-2023 Howard M. Harte.                              *
  * https://github.com/hharte                                             *
  *                                                                       *
  * Permission is hereby granted, free of charge, to any person obtaining *
@@ -55,7 +55,7 @@
 #define UART_MSG    (1 << 6)
 #define VERBOSE_MSG (1 << 7)
 
-#define ADCS6_MAX_UNITS    8
+#define ADCS6_MAX_UNITS     8
 #define ADCS6_ROM_SIZE      (2 * 1024)
 #define ADCS6_ADDR_MASK     (ADCS6_ROM_SIZE - 1)
 
@@ -215,10 +215,10 @@ static UNIT adcs6_unit[] = {
     { UDATA (&adcs6_svc, UNIT_FIX + UNIT_ATTABLE + UNIT_DISABLE + UNIT_ROABLE, ADCS6_CAPACITY) },
     { UDATA (&adcs6_svc, UNIT_FIX + UNIT_ATTABLE + UNIT_DISABLE + UNIT_ROABLE, ADCS6_CAPACITY) },
     { UDATA (&adcs6_svc, UNIT_FIX + UNIT_ATTABLE + UNIT_DISABLE + UNIT_ROABLE, ADCS6_CAPACITY) },
-    { UDATA (&adcs6_ctc_svc, UNIT_DISABLE, 0) },  /* CTC0 */
-    { UDATA (&adcs6_ctc_svc, UNIT_DISABLE, 0) },  /* CTC1 */
-    { UDATA (&adcs6_ctc_svc, UNIT_DISABLE, 0) },  /* CTC2 */
-    { UDATA (&adcs6_ctc_svc, UNIT_DISABLE, 0) },  /* CTC3 */
+    { UDATA (&adcs6_ctc_svc, UNIT_DISABLE, 0), ADCS6_WAIT },  /* CTC0 */
+    { UDATA (&adcs6_ctc_svc, UNIT_DISABLE, 0), ADCS6_WAIT },  /* CTC1 */
+    { UDATA (&adcs6_ctc_svc, UNIT_DISABLE, 0), ADCS6_WAIT },  /* CTC2 */
+    { UDATA (&adcs6_ctc_svc, UNIT_DISABLE, 0), ADCS6_WAIT },  /* CTC3 */
 };
 
 static REG adcs6_reg[] = {
@@ -639,6 +639,15 @@ static t_stat adcs6_reset(DEVICE *dptr)
     PNP_INFO *pnp = (PNP_INFO *)dptr->ctxt;
     int i;
 
+    for (i = 0; i < ADCS6_MAX_UNITS; i++) {
+        adcs6_unit[i].u4 = i;
+    }
+
+    sim_set_uname(&adcs6_unit[4], "ADCS6_CTC0");
+    sim_set_uname(&adcs6_unit[5], "ADCS6_CTC1");
+    sim_set_uname(&adcs6_unit[6], "ADCS6_CTC2");
+    sim_set_uname(&adcs6_unit[7], "ADCS6_CTC3");
+
     if(dptr->flags & DEV_DIS) { /* Disconnect ROM and I/O Ports */
         if (adcs6_info->rom_disabled == FALSE) {
             sim_map_resource(pnp->mem_base, pnp->mem_size, RESOURCE_TYPE_MEMORY, &adcs6rom, "adcs6rom", TRUE);
@@ -700,23 +709,6 @@ static t_stat adcs6_reset(DEVICE *dptr)
             sim_printf("%s: error mapping I/O resource at 0x%04x\n", __FUNCTION__, pnp->io_base);
             return SCPE_ARG;
         }
-
-        for (i = 0; i < ADCS6_MAX_UNITS; i++) {
-            adcs6_unit[i].u4 = i;
-        }
-
-        adcs6_unit[4].u4 = 4;
-        sim_set_uname(&adcs6_unit[4], "ADCS6_CTC0");
-        adcs6_unit[4].wait = ADCS6_WAIT;
-        adcs6_unit[5].u4 = 5;
-        sim_set_uname(&adcs6_unit[5], "ADCS6_CTC1");
-        adcs6_unit[5].wait = ADCS6_WAIT;
-        adcs6_unit[6].u4 = 6;
-        sim_set_uname(&adcs6_unit[6], "ADCS6_CTC2");
-        adcs6_unit[6].wait = ADCS6_WAIT;
-        adcs6_unit[7].u4 = 7;
-        sim_set_uname(&adcs6_unit[7], "ADCS6_CTC3");
-        adcs6_unit[7].wait = ADCS6_WAIT;
 
         /* Reset memory control registers */
         adcs6_info->mctrl0 = 0;


### PR DESCRIPTION
**Summary of change:**

* Resolve issue #164: Proper initialization of the ADCS6 unit data structure depended on the ADCS6 device being enabled.  In cases where the ADCS6 unit was not enabled, non-debug builds may crash on some host platforms depending on compiler/memory layout.

Thanks @markpizz for tracking this down and for the fix.

**Compiled with:**

* VS 2022 17.4.4 (Debug and Release)
* VS 2008 (Debug and Release)
* MacOS (x64) clang-1400.0.29.202
* Linux gcc 10.2.1

**Automated tests:**
SIMH running on Windows 10 (debug/release), Windows 11 (debug/release), Linux (ARM), MacOS (x64):

[CompuPro CP/M-80](https://schorn.ch/cpm/zip/cpm86.zip)
[CompuPro CP/M-86](https://schorn.ch/cpm/zip/cpm86.zip)
[SCP 86-DOS](https://schorn.ch/cpm/zip/86dos.zip)
[MS-DOS 2.11](https://github.com/hharte/altairz80-packages/tree/main/msdos211_test)
[CompuPro CP/M-68K v1.3](https://github.com/hharte/altairz80-packages/tree/main/ccpm68k13) (68000 and 68010 versions)
[CP/M-68K v1.2](https://schorn.ch/cpm/zip/cpm68k.zip)
[Advanced Digital Super-Six CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm2)
[Advanced Digital Super-Six CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm3)
[DIGITEX CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm2)
[DIGITEX CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm3)
[DIGITEX OASIS multi-user version 5.6](https://github.com/open-simh/simh/pull/github.com/hharte/altairz80-packages/tree/main/dig_oasis56)
[CP/M-80 (Altair)](https://schorn.ch/cpm/zip/cpm2.zip) ZEXALL Z80 instruction set test.

FYI, @psco 