### PR TITLE
SDS:reset cr_eor on disconnect

### DIFF
--- a/SDS/sds_cr.c
+++ b/SDS/sds_cr.c
@@ -24,6 +24,7 @@
    in this Software without prior written authorization from Ken Rector.
 
    03-Mar-20    kenr    Initial Version
+   10-Mar-23    kenr    Reset cr_eor on disconnect
 
    */
 
@@ -220,6 +221,8 @@ t_stat cr_devio (uint32 fnc, uint32 inst, uint32 *dat) {
         case IO_DISC:                                   /* disconnect */
             xfr_req = xfr_req & ~XFR_CR;                /* clr xfr flag */
             sim_cancel (uptr);                          /* deactivate unit */
+            cr_eor = 0;
+            uptr->STATUS = 0;
             break;
         case IO_SKS:                                    /* SKS */
             new_ch = I_GETSKCH (inst);                  /* get chan # */


### PR DESCRIPTION
SDS: reset cr_eor on disconnect. Caused algol compiler to hang