### PR TITLE
sigma: Correct recognition of pending DP seek interrupt.

### DIFF
--- a/sigma/sigma_coc.c
+++ b/sigma/sigma_coc.c
@@ -277,7 +277,9 @@ switch (op) {                                           /* case on op */
 
     case OP_SIO:                                        /* start I/O */
         *dvst = mux_tio_status ();                      /* get status */
-        if ((*dvst & DVS_CST) == 0) {                   /* ctrl idle? */
+        if (chan_chk_dvi (dva))                         /* int pending? */
+              *dvst |= (CC2 << DVT_V_CC);               /* SIO fails */
+          else if ((*dvst & DVS_CST) == 0) {            /* ctrl idle? */
             muxc_cmd = MUXC_INIT;                       /* start dev thread */
             sim_activate (&mux_unit[MUXC], chan_ctl_time);
             }

--- a/sigma/sigma_dk.c
+++ b/sigma/sigma_dk.c
@@ -170,7 +170,9 @@ switch (op) {                                           /* case on op */
 
     case OP_SIO:                                        /* start I/O */
         *dvst = dk_tio_status (un);                     /* get status */
-        if ((*dvst & (DVS_CST|DVS_DST)) == 0) {         /* ctrl + dev idle? */
+        if (chan_chk_dvi (dva))                         /* int pending? */
+            *dvst |= (CC2 << DVT_V_CC);                 /* SIO fails */
+        else if ((*dvst & (DVS_CST|DVS_DST)) == 0) {    /* ctrl + dev idle? */
             dk_cmd = DKS_INIT;                          /* start dev thread */
             sim_activate (&dk_unit[un], chan_ctl_time);
             }

--- a/sigma/sigma_io.c
+++ b/sigma/sigma_io.c
@@ -353,11 +353,6 @@ if (!io_init_inst (rn, ad, ch, dev, R[0])) {            /* valid inst? */
     CC |= CC1|CC2;
     return 0;
     }
-if (chan[ch].chf[dev] & CHF_INP) {                      /* int pending? */
-    chan[ch].disp[dev] (OP_TIO, ad, &dvst);             /* get status */
-    CC |= (CC2 | io_set_status (rn, ch, dev, dvst, 0)); /* set status */
-    return 0;
-    }
 st = chan[ch].disp[dev] (OP_SIO, ad, &dvst);            /* start I/O */
 CC |= io_set_status (rn, ch, dev, dvst, 0);             /* set status */
 if (CC & cpu_tab[cpu_model].iocc)                       /* error? */
@@ -806,7 +801,7 @@ if (chan[ch].chi[dev] & CHI_CTL)                        /* ctl int pending? */
 else return -1;
 }
 
-/* Set device interrupt */
+/* Set, check device interrupt */
 
 void chan_set_dvi (uint32 dva)
 {
@@ -815,6 +810,16 @@ uint32 dev = DVA_GETDEV (dva);
 
 chan[ch].chf[dev] |= CHF_INP;                           /* int pending */
 return;
+}
+
+t_bool chan_chk_dvi (uint32 dva)
+{
+uint32 ch = DVA_GETCHAN (dva);                          /* get ch, dev */
+uint32 dev = DVA_GETDEV (dva);
+
+if ((chan[ch].chf[dev] & CHF_INP) != 0)
+    return TRUE;
+return FALSE;
 }
 
 /* Called by device reset to reset channel registers */

--- a/sigma/sigma_io_defs.h
+++ b/sigma/sigma_io_defs.h
@@ -252,6 +252,7 @@ void chan_set_chi (uint32 dva, uint32 fl);
 void chan_set_dvi (uint32 dva);
 int32 chan_clr_chi (uint32 dva);
 int32 chan_chk_chi (uint32 dva);
+t_bool chan_chk_dvi (uint32 dva);
 uint32 chan_end (uint32 dva);
 uint32 chan_uen (uint32 dva);
 uint32 chan_RdMemB (uint32 dva, uint32 *dat);

--- a/sigma/sigma_lp.c
+++ b/sigma/sigma_lp.c
@@ -180,7 +180,9 @@ switch (op) {                                           /* case on op */
 
     case OP_SIO:                                        /* start I/O */
         *dvst = lp_tio_status ();                       /* get status */
-        if ((*dvst & DVS_DST) == 0) {                   /* idle? */
+        if (chan_chk_dvi (dva))                         /* int pending? */
+            *dvst |= (CC2 << DVT_V_CC);                 /* SIO fails */
+        else if ((*dvst & DVS_DST) == 0) {              /* idle? */
             lp_cmd = LPS_INIT;                          /* start dev thread */
             sim_activate (&lp_unit, chan_ctl_time);
             }

--- a/sigma/sigma_mt.c
+++ b/sigma/sigma_mt.c
@@ -237,7 +237,9 @@ switch (op) {                                           /* case on op */
 
     case OP_SIO:                                        /* start I/O */
         *dvst = mt_tio_status (un);                     /* get status */
-        if ((*dvst & (DVS_CST|DVS_DST)) == 0) {         /* ctrl + dev idle? */
+         if (chan_chk_dvi (dva))                         /* int pending? */
+            *dvst |= (CC2 << DVT_V_CC);                 /* SIO fails */
+        else if ((*dvst & (DVS_CST|DVS_DST)) == 0) {    /* ctrl + dev idle? */
             uptr->UCMD = MCM_INIT;                      /* start dev thread */
             sim_activate (uptr, chan_ctl_time);
             }

--- a/sigma/sigma_pt.c
+++ b/sigma/sigma_pt.c
@@ -119,7 +119,9 @@ switch (op) {                                           /* case on op */
 
     case OP_SIO:                                        /* start I/O */
         *dvst = pt_tio_status ();                       /* get status */
-        if ((*dvst & DVS_DST) == 0) {                   /* idle? */
+        if (chan_chk_dvi (dva))                         /* int pending? */
+            *dvst |= (CC2 << DVT_V_CC);                 /* SIO fails */
+        else if ((*dvst & DVS_DST) == 0) {              /* idle? */
             pt_cmd = PTS_INIT;                          /* start dev thread */
             sim_activate (&pt_unit[PTR], chan_ctl_time);
             }

--- a/sigma/sigma_rad.c
+++ b/sigma/sigma_rad.c
@@ -211,7 +211,9 @@ switch (op) {                                           /* case on op */
 
     case OP_SIO:                                        /* start I/O */
         *dvst = rad_tio_status (un);                    /* get status */
-        if ((*dvst & (DVS_CST|DVS_DST)) == 0) {         /* ctrl + dev idle? */
+        if (chan_chk_dvi (dva))                         /* int pending? */
+            *dvst |= (CC2 << DVT_V_CC);                 /* SIO fails */
+        else if ((*dvst & (DVS_CST|DVS_DST)) == 0) {    /* ctrl + dev idle? */
             rad_cmd = RADS_INIT;                        /* start dev thread */
             sim_activate (&rad_unit[un], chan_ctl_time);
             }

--- a/sigma/sigma_tt.c
+++ b/sigma/sigma_tt.c
@@ -134,7 +134,9 @@ switch (op) {                                           /* case on op */
 
     case OP_SIO:                                        /* start I/O */
         *dvst = tt_tio_status ();                       /* get status */
-        if ((*dvst & DVS_DST) == 0) {                   /* idle? */
+        if (chan_chk_dvi (dva))                         /* int pending? */
+            *dvst |= (CC2 << DVT_V_CC);                 /* SIO fails */
+        else if ((*dvst & DVS_DST) == 0) {              /* idle? */
             tt_cmd = TTS_INIT;                          /* start dev thread */
             sim_activate (&tt_unit[TTO], chan_ctl_time);
             }


### PR DESCRIPTION
This corrects an error that caused SIO reject when SIO occured before a pending seek interrupt on a different device.
 - Move the interrupt pending test from sigma_io.c into each device.
 - Make the sigma_dp.c test a special case that looks for pending seek interrupts.