### PR TITLE
sigma: MT: AIO must mask unit number before calling TDV status.

### DIFF
--- a/sigma/sigma_bugs.txt
+++ b/sigma/sigma_bugs.txt
@@ -128,6 +128,9 @@
 122. COC: Received break generates a data-in channel transaction with a flag bit set
      in the line number.
 123. DP: dp_inv_adr error must set a TDV visible flag (i.e., PGE) before UEND.
+124. IO, all devices: moved SIO reject-on-interrupt test to devices.
+125. DP: SIO will knock down pending device interrupts and allow operation to proceed.
+126. MT: AIO must mask unit number before calling TDV status.
 
 Diagnostic Notes
 ----------------

--- a/sigma/sigma_mt.c
+++ b/sigma/sigma_mt.c
@@ -267,7 +267,8 @@ switch (op) {                                           /* case on op */
 
     case OP_AIO:                                        /* acknowledge int */
         un = mt_clr_int (mt_dib.dva);                   /* clr int, get unit and flag */
-        *dvst = (mt_tdv_status (un) & MTAI_MASK) |      /* device status */
+        *dvst =
+            (mt_tdv_status (un & DVA_M_DEVMU) & MTAI_MASK) | /* device status */
             (un & MTAI_INT) |                           /* device int flag */
             ((un & DVA_M_UNIT) << DVT_V_UN);            /* unit number */
         break;


### PR DESCRIPTION
sigma_mt.c - AIO must mask unit number before calling TDV status.