### PR TITLE
SCP: Change declaration of get_yn() to have boolean argument and return value

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -10429,7 +10429,7 @@ return (CONST char *)get_glyph_gen (iptr, optr, 0, TRUE, FALSE, 0);
         result  =       true if yes, false if no
 */
 
-t_stat get_yn (const char *ques, t_stat deflt)
+t_bool get_yn (const char *ques, t_bool deflt)
 {
 char cbuf[CBUFSIZE];
 const char *cptr;
@@ -16515,7 +16515,7 @@ for (i = 0; (dptr = sim_devices[i]) != NULL; i++) {
         stat = tstat;
         sim_printf ("%s device tests returned: %d - %s\n", dptr->name, SCPE_BARE_STATUS (tstat), sim_error_text (tstat));
         if (sim_ttisatty()) {
-            if (get_yn ("Continue with additional tests? [N] ", SCPE_STOP) == SCPE_STOP)
+            if (get_yn ("Continue with additional tests? [N] ", FALSE) == FALSE)
                 break;
             }
         else

--- a/scp.h
+++ b/scp.h
@@ -163,7 +163,7 @@ t_stat show_writelock (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 const char *sim_dname (DEVICE *dptr);
 const char *sim_uname (UNIT *dptr);
 const char *sim_set_uname (UNIT *uptr, const char *uname);
-t_stat get_yn (const char *ques, t_stat deflt);
+t_bool get_yn (const char *ques, t_bool deflt);
 void sim_srand (unsigned int seed);
 int sim_rand (void);
 #ifdef RAND_MAX


### PR DESCRIPTION

- Fix improper get_yn() use in test library logic

Reported by Peter Schorn