### PR TITLE
3B2: LPT Device; MMU and SCSI fixes

### DIFF
--- a/3B2/3b2_cpu.c
+++ b/3B2/3b2_cpu.c
@@ -846,9 +846,9 @@ t_stat cpu_show_cio(FILE *st, UNIT *uptr, int32 val, CONST void *desc)
     fprintf(st, "---------------------\n");
     for (slot = 0; slot < CIO_SLOTS; slot++) {
         if (cio[slot].populated) {
-            fprintf(st, "   %2d       %s\n", slot, cio[slot].name);
+            fprintf(st, "   %2d       %s\n", slot + 1, cio[slot].name);
         } else {
-            fprintf(st, "   %2d       -\n", slot);
+            fprintf(st, "   %2d       -\n", slot + 1);
         }
     }
 

--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -158,6 +158,7 @@ extern DEVICE timer_dev;
 extern DEVICE tod_dev;
 extern DEVICE tti_dev;
 extern DEVICE tto_dev;
+extern DEVICE lpt_dev;
 #if defined(REV3)
 extern DEVICE flt_dev;
 extern DEVICE ha_dev;

--- a/3B2/3b2_ports.h
+++ b/3B2/3b2_ports.h
@@ -51,16 +51,15 @@
 #define PORTS_IPL       10
 #define PORTS_VERSION   1
 
-#define MAX_CARDS       8  /* Up to 8 PORTS cards with 32 lines total
-                              supported */
-#define PORTS_LINES     4
-#define PORTS_RCV_QUEUE 5
+#define MAX_CARDS        8   /* Up to 8 PORTS cards supported */
+#define PORTS_CENTRONICS 4   /* Subdevice 4 is the centronics port */
+#define PORTS_LINES      4   /* Subdevices 0-3 are RS232 ports */
+#define PORTS_RCV_QUEUE  5   /* Total of 5 receive queues for all ports */
 
 /*
- * Sub-field values for the PPC_DEVICE request entry; these are placed
- * in app_data.bt[0] in the PPC_DEVICE application field. The prefix
- * DR indicates that this is a code for use in "device" request
- * entries only.
+ * Sub-field values for the PPC_DEVICE request entry; these are placed in
+ * app_data.bt[0] in the PPC_DEVICE application field. The prefix DR
+ * indicates that this is a code for use in "device" request entries only.
 */
 
 #define DR_ENA      1       /* enable a device */
@@ -222,6 +221,11 @@ t_stat ports_xmt_svc(UNIT *uptr);
 t_stat ports_cio_svc(UNIT *uptr);
 t_stat ports_attach(UNIT *uptr, CONST char *cptr);
 t_stat ports_detach(UNIT *uptr);
+t_stat lpt_reset (DEVICE *dptr);
+t_stat lpt_attach (UNIT *uptr, CONST char *ptr);
+t_stat lpt_detach (UNIT *uptr);
+t_stat lpt_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr);
+const char *lpt_description (DEVICE *dptr);
 void ports_sysgen(uint8 slot);
 void ports_express(uint8 slot);
 void ports_full(uint8 slot);

--- a/3B2/3b2_rev2_defs.h
+++ b/3B2/3b2_rev2_defs.h
@@ -97,6 +97,8 @@
 #define MEMID_1M        2
 #define MEMID_2M        1
 #define MEMID_4M        3
+#define MMUBASE         0x40000
+#define MMUSIZE         0x1000
 
 /* DMA Controller */
 #define DMACBASE        0x48000

--- a/3B2/3b2_rev2_mmu.h
+++ b/3B2/3b2_rev2_mmu.h
@@ -140,9 +140,6 @@
  *
  ***********************************************************************/
 
-#define MMUBASE 0x40000
-#define MMUSIZE 0x1000
-
 #define MMU_SRS  0x04       /* Section RAM array size (words) */
 #define MMU_SDCS 0x20       /* Segment Descriptor Cache H/L array size
                                (words) */

--- a/3B2/3b2_rev2_sys.c
+++ b/3B2/3b2_rev2_sys.c
@@ -60,6 +60,7 @@ DEVICE *sim_devices[] = {
     &if_dev,
     &id_dev,
     &ports_dev,
+    &lpt_dev,
     &ctc_dev,
     &ni_dev,
     NULL
@@ -77,6 +78,7 @@ void full_reset()
     id_reset(&id_dev);
     csr_reset(&csr_dev);
     ports_reset(&ports_dev);
+    lpt_reset(&lpt_dev);
     ctc_reset(&ctc_dev);
     ni_reset(&ni_dev);
 }

--- a/3B2/3b2_rev3_mmu.c
+++ b/3B2/3b2_rev3_mmu.c
@@ -600,6 +600,10 @@ void mmu_write(uint32 pa, uint32 val, size_t size)
         /* Flush all PDC cache entries for this section */
         for (i = 0; i < MMU_PDCS; i++) {
             if (((mmu_state.pdch[i] >> 24) & 0x3) == index) {
+                sim_debug(MMU_CACHE_DBG, &mmu_dev,
+                          "Flushing MMU PDC entry at index %d "
+                          "(pdc_lo=%08x pdc_hi=%08x)\n",
+                          i, mmu_state.pdcl[i], mmu_state.pdch[i]);
                 mmu_state.pdch[i] &= ~(PDC_G_MASK);
             }
         }
@@ -1041,8 +1045,9 @@ uint32 mmu_xlate_addr(uint32 va, uint8 r_acc)
 
     succ = mmu_decode_va(va, r_acc, TRUE, &pa);
 
+    mmu_state.var = va;
+
     if (succ == SCPE_OK) {
-        mmu_state.var = va;
         return pa;
     } else {
         cpu_abort(NORMAL_EXCEPTION, EXTERNAL_MEMORY_FAULT);

--- a/3B2/3b2_rev3_sys.c
+++ b/3B2/3b2_rev3_sys.c
@@ -60,6 +60,7 @@ DEVICE *sim_devices[] = {
     &if_dev,
     &ha_dev,
     &ports_dev,
+    &lpt_dev,
     &ni_dev,
     NULL
 };
@@ -76,5 +77,6 @@ void full_reset()
     ha_reset(&ha_dev);
     csr_reset(&csr_dev);
     ports_reset(&ports_dev);
+    lpt_reset(&lpt_dev);
     ni_reset(&ni_dev);
 }

--- a/3B2/3b2_scsi.c
+++ b/3B2/3b2_scsi.c
@@ -506,7 +506,16 @@ static void ha_boot_tape(UNIT *uptr, uint8 tc)
         return;
     }
 
-    r = sim_tape_rdrecf(uptr, buf, &sectsread, HA_BLKSZ); /* Read block 0 */
+    r = sim_tape_sprecf(uptr, &sectsread);                /* Skip block 0 */
+
+    if (r != SCPE_OK) {
+        sim_debug(HA_TRACE, &ha_dev,
+                  "[ha_boot_tape] Could not skip block 0.\n");
+        HA_STAT(tc, HA_CKCON, CIO_SUCCESS);
+        return;
+    }
+
+    r = sim_tape_rdrecf(uptr, buf, &sectsread, HA_BLKSZ); /* Read block 1 */
 
     if (r != SCPE_OK) {
         sim_debug(HA_TRACE, &ha_dev,
@@ -522,8 +531,6 @@ static void ha_boot_tape(UNIT *uptr, uint8 tc)
     sim_debug(HA_TRACE, &ha_dev,
               "[ha_boot_tape] Transfered 512 bytes to 0x%08x\n",
               HA_BOOT_ADDR);
-
-    r = sim_tape_sprecf(uptr, &sectsread);           /* Skip block 1 */
 
     HA_STAT(tc, HA_GOOD, CIO_SUCCESS);
 


### PR DESCRIPTION
This change adds support for printing to an attached text file via the Centronics port of a simulated PORTS feature card. A new device named "LPT" has been added. See "help lpt" for documentation.

Additionally, there has been a fix to a bug in the SCSI tape boot implementation and a very minor bug fix to the Rev 3 MMU.