### PR TITLE
3B2: Fix for diagnostics timer hang

### DIFF
--- a/3B2/3b2_timer.c
+++ b/3B2/3b2_timer.c
@@ -92,9 +92,13 @@
 #define QUICK_DELAY 100
 #endif
 
-#define DELAY_US(C,N) ((TIMER_MODE(C) == 3) ?                \
-                       (TIME_BASE[(N)] * (C)->divider) / 2 : \
-                       TIME_BASE[(N)] * (C)->divider)
+#define MIN_US 100
+
+#define CALC_US(C,N) ((TIMER_MODE(C) == 3) ?      \
+                      (TIME_BASE[(N)] * (C)->divider) / 2 : \
+                      TIME_BASE[(N)] * (C)->divider)
+
+#define DELAY_US(C,N) (MAX(MIN_US, CALC_US((C),(N))))
 
 #if defined(REV3)
 /* Microseconds per step (Version 3 system board):


### PR DESCRIPTION
Under certain circumstances, the timer resolution in the Version 3 could become coarse enough that very short timer intervals would lead to an infinite loop of bus errors when running timer firmware diagnostics.