### PR TITLE
SCP: Include all simh supported system includes in sim_defs.h

### DIFF
--- a/sim_defs.h
+++ b/sim_defs.h
@@ -136,6 +136,9 @@ extern int sim_vax_snprintf(char *buf, size_t buf_size, const char *fmt, ...);
 #include <errno.h>
 #include <limits.h>
 #include <ctype.h>
+#include <math.h>
+#include <setjmp.h>
+
 
 #ifndef EXIT_FAILURE
 #define EXIT_FAILURE 1


### PR DESCRIPTION
Only SCP libraries should be including additional OS specific include files since they cover both:
   1) Are responsible for platform specific details integrated into simh
       support
and
   2) Implement extended functionality optimally considering the proper
       behaviors to cooperate with the simh event system and existing
       capabilities.

Simulator code can optionally include any of these system include files:
  <stddef.h>, <stdlib.h>, <stdio.h>, <stdarg.h>, <string.h>, <errno.h>.
  <limits.h>, <ctype.h>, <math.h>, <setjmp.h>

Such inclusion will be redundant with what is already provided here by sim_defs.h.  Simulator code should include SCP provided include files:
  "scp.h", "sim_card.h", "sim_console.h", "sim_disk.h", "sim_ether.h",
  "sim_fio.h", "sim_imd.h", "sim_scsi.h", "sim_serial.h", "sim_tape.h",
  "sim_timer.h", "sim_tmxr.h", "sim_video.h"
depending on the specific needs of the device being simulated.