### PR TITLE
Fix library-related compile errors.

### DIFF
--- a/sim_video.c
+++ b/sim_video.c
@@ -27,6 +27,9 @@
    11-Jun-2013  MB      First version
 */
 
+#if defined(HAVE_LIBPNG) && defined(USE_SIM_VIDEO) && defined(HAVE_LIBSDL)
+#include <png.h>
+#endif
 #include "sim_video.h"
 #include "scp.h"
 
@@ -148,7 +151,6 @@ static char tmp_key_name[40];
  * http://www.libpng.org/pub/png/src/libpng-LICENSE.txt
  */
 #include <SDL.h>
-#include <png.h>
 #include <zlib.h>
 
 #define SUCCESS 0

--- a/sim_video.c
+++ b/sim_video.c
@@ -1812,10 +1812,12 @@ if (!vptr->vid_texture) {
 
 vptr->vid_format = SDL_AllocFormat (SDL_PIXELFORMAT_ARGB8888);
 
+#ifdef SDL_WINDOW_RESIZABLE
 if (vptr->vid_flags & SIM_VID_RESIZABLE) {
     SDL_SetWindowResizable(vptr->vid_window, SDL_TRUE);
     SDL_RenderSetIntegerScale(vptr->vid_renderer, SDL_TRUE);
 }
+#endif
 
 SDL_StopTextInput ();
 


### PR DESCRIPTION
- libpng is fussy about setjmp.h.

This happens on Ubuntu 16.  My other machines are on Ubuntu 22, where is works fine.

- Older versions of libsdl don't have SDL_SetWindowResizable.

This API was introduced with SDL 2.0.5.