### PR TITLE
SCP: Don't malloc ep->match_pattern twice

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -13119,8 +13119,6 @@ else {
     ep->match = match_buf;
     ep->size = match_size;
     }
-ep->match_pattern = (char *)malloc (strlen (match) + 1);
-strcpy (ep->match_pattern, match);
 if (ep->act) {                                          /* replace old action? */
     free (ep->act);                                     /* deallocate */
     ep->act = NULL;                                     /* now no action */


### PR DESCRIPTION
`ep->match_pattern` was being allocated twice, leading to a memory leak, as mentioned in #235 