### PR TITLE
Add Coverity Scan CI job

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,0 +1,59 @@
+name: Coverity Scan
+on:
+  schedule:
+    - cron: '0 18 * * 2,4' # Bi-weekly at 18:00 UTC on Tuesday and Thursday
+
+# Automatically cancel any previous workflow on new push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  latest:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Determine current repository
+        id: "determine-repo"
+        run: echo "repo=${GITHUB_REPOSITORY}" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v3
+      - name: Download Coverity Build Tool
+        run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=open-simh%2Fsimh" -O cov-analysis-linux64.tar.gz
+          mkdir cov-analysis-linux64
+          tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        if: steps.determine-repo.outputs.repo == 'open-simh/simh'
+
+      - name: Fixed world writable dirs
+        run: |
+          chmod go-w $HOME
+          sudo chmod -R go-w /usr/share
+        if: steps.determine-repo.outputs.repo == 'open-simh/simh'
+        
+      - name: Installing build dependencies
+        run: |
+           sh -ex .travis/deps.sh linux
+           sudo apt --assume-yes install -ym ninja-build
+        if: steps.determine-repo.outputs.repo == 'open-simh/simh'
+
+      - name: Build with cov-build
+        run: |
+          export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
+          cov-build --dir cov-int cmake/cmake-builder.sh --config Release --flavor ninja --lto --notest --parallel --verbose --cpack_suffix x86_64-${{matrix.os}}
+        if: steps.determine-repo.outputs.repo == 'open-simh/simh'
+
+      - name: Submit the result to Coverity Scan
+        run: |
+          tar czvf simh.tgz cov-int
+          curl \
+            --form token=$TOKEN \
+            --form email=noreply@opensimh.org \
+            --form file=@simh.tgz \
+            --form version=trunk \
+            --form description="opensimh" \
+            https://scan.coverity.com/builds?project=open-simh%2Fsimh
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        if: steps.determine-repo.outputs.repo == 'open-simh/simh'


### PR DESCRIPTION
It requires setting also the `COVERITY_SCAN_TOKEN` at the secrets page of the repository settings. It also assumes the project is registered on Coverity Scan under the name of `open-simh/simh` using the GitHub integration.

Closes https://github.com/open-simh/simh/issues/234

I didn't test it yet, since this kind of thing is hard to test without actually running the CI job.