### PR TITLE
AltairZ80: IBC MCC: Clean up HDC.

### DIFF
--- a/AltairZ80/ibc_mcc_hdc.c
+++ b/AltairZ80/ibc_mcc_hdc.c
@@ -49,7 +49,8 @@
 #define IBC_HDC_MAX_DRIVES          4       /* Maximum number of drives supported */
 #define IBC_HDC_MAX_SECLEN          256     /* Maximum of 256 bytes per sector */
 #define IBC_HDC_FORMAT_FILL_BYTE    0xe5    /* Real controller uses 0, but we
-                                               choose 0xe5 so the disk shows                                               up as blank under CP/M. */
+                                               choose 0xe5 so the disk shows
+                                               up as blank under CP/M. */
 #define IBC_HDC_MAX_CYLS            1024
 #define IBC_HDC_MAX_HEADS           16
 #define IBC_HDC_MAX_SPT             256
@@ -67,6 +68,7 @@
 #define TF_TRKH     7
 #define TF_FIFO     8
 
+#define IBC_HDC_STATUS_BUSY         (1 << 4)
 #define IBC_HDC_STATUS_ERROR        (1 << 0)
 
 #define IBC_HDC_ERROR_ID_NOT_FOUND  (1 << 4)
@@ -536,7 +538,7 @@ static t_stat IBC_HDC_doCommand(void)
     IBC_HDC_DRIVE_INFO* pDrive = &ibc_hdc_info->drive[ibc_hdc_info->sel_drive];
     uint8 cmd = ibc_hdc_info->taskfile[TF_CMD] & IBC_HDC_CMD_MASK;
 
-    pDrive->cur_cyl    = ibc_hdc_info->taskfile[TF_TRKH] << 8;
+    pDrive->cur_cyl    = (uint16)ibc_hdc_info->taskfile[TF_TRKH] << 8;
     pDrive->cur_cyl   |= ibc_hdc_info->taskfile[TF_TRKL];
     pDrive->xfr_nsects = ibc_hdc_info->taskfile[TF_NSEC];
     pDrive->cur_head   = ibc_hdc_info->taskfile[TF_HEAD];
@@ -569,7 +571,7 @@ static t_stat IBC_HDC_doCommand(void)
         if (IBC_HDC_Validate_CHSN(pDrive) != SCPE_OK) break;
 
         /* Calculate file offset */
-        file_offset = (pDrive->cur_cyl * pDrive->nheads * pDrive->nsectors);   /* Full cylinders */
+        file_offset  = (pDrive->cur_cyl * pDrive->nheads * pDrive->nsectors);   /* Full cylinders */
         file_offset += (pDrive->cur_head * pDrive->nsectors);   /* Add full heads */
         file_offset += (pDrive->cur_sect);  /* Add sectors for current request */
         file_offset *= pDrive->sectsize;    /* Convert #sectors to byte offset */


### PR DESCRIPTION
## AltairZ80: IBC MCC: Clean up HDC.

### Summary
Small cleanup for the IBC MCC hard disk controller.

### Compiled with:

* VS 2022 17.6.3 - CMake
* MacOS (x64) clang-1400.0.29.202
* Linux gcc 10.2.1

### [Automated tests](https://github.com/hharte/altairz80-tests):
SIMH running on Windows, Linux (ARM), MacOS (x64):

[CompuPro CP/M-80](https://schorn.ch/cpm/zip/cpm86.zip)
[CompuPro CP/M-86](https://schorn.ch/cpm/zip/cpm86.zip)
[SCP 86-DOS](https://schorn.ch/cpm/zip/86dos.zip)
[MS-DOS 2.11](https://github.com/hharte/altairz80-packages/tree/main/msdos211_test) - Builds [MS-DOS 2.11 from source](https://github.com/hharte/ms-dos).
[CompuPro CP/M-68K v1.3](https://github.com/hharte/altairz80-packages/tree/main/ccpm68k13) (68000 and 68010 versions)
[CP/M-68K v1.2](https://schorn.ch/cpm/zip/cpm68k.zip)
[Advanced Digital Super-Six CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm2)
[Advanced Digital Super-Six CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm3)
[DIGITEX CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm2)
[DIGITEX CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm3)
[DIGITEX OASIS multi-user version 5.6](https://github.com/open-simh/simh/pull/github.com/hharte/altairz80-packages/tree/main/dig_oasis56)
[MultiStar: IBC OASIS multi-user version 5.6](https://github.com/hharte/altairz80-packages/blob/main/ibcmcc_oasis56)
[MegaStar: IBC OASIS multi-user version 5.6](https://github.com/hharte/altairz80-packages/blob/main/ibcscc_oasis56)
[CP/M-80 (Altair)](https://schorn.ch/cpm/zip/cpm2.zip) ZEXALL Z80 instruction set test.
[CP/M 3 (Altair)](https://schorn.ch/cpm/zip/cpm3.zip) Banked Memory Test.

FYI, @psco