### PR TITLE
Visual Studio Projects: Force build to update to the latest windows-build

### DIFF
--- a/Visual Studio Projects/Pre-Build-Event.cmd
+++ b/Visual Studio Projects/Pre-Build-Event.cmd
@@ -29,7 +29,7 @@ rem
 rem Everything implicitly requires BUILD to also be set to have 
 rem any meaning, it always gets set.
 set _X_BUILD=BUILD
-set _X_REQUIRED_WINDOWS_BUILD=20220119
+set _X_REQUIRED_WINDOWS_BUILD=20230621
 call :FindVCVersion _VC_VER
 
 set _PDB=%~dpn1.pdb


### PR DESCRIPTION
Windows-build has been updated to solve #255.

This commit causes local builds (and CI ones) to update their local copy of the windows build components to build cleanly with Visual Studio 2022 v17.6.4