### PR TITLE
sigma: Correct DP Sense Length error(Bob Supnick)

### DIFF
--- a/sigma/sigma_dp.c
+++ b/sigma/sigma_dp.c
@@ -780,7 +780,7 @@ switch (uptr->UCMD) {
             if (CHS_IFERR (st))                         /* channel error? */
                 return dp_chan_err (dva, st);
             }
-        if ((i != DPS_NBY) || (st != CHS_ZBC)) {        /* length error? */
+        if (!DP_Q10B (ctx->dp_ctype) && (st != CHS_ZBC)) { /* 16B only: length error? */
             ctx->dp_flags |= DPF_PGE;                   /* set prog err */
             if (chan_set_chf (dva, CHF_LNTE))           /* do we care? */
                 return SCPE_OK;


### PR DESCRIPTION
sigma_dp.c:   SENSE operation is returning a length error when it shouldn't.
CP-V requests x10 (16) bytes and status returned from chan_WrMemB() is 0x8001, and
CP-V requests x4 bytes and returned the same status.

This fix accounts for the 'no errors on 10 byte model' and 'error if > 16'. A 0 transfer length is 
considered to be 65536, so it will always cause a length error in a 16 byte model. 