### PR TITLE
MAKEFILE: cleanup junk characters from 2c89387

### DIFF
--- a/makefile
+++ b/makefile
@@ -826,7 +826,7 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
   ifeq (cygwin,$(OSTYPE))
     LIBEXT = $(LIBEXTSAVE)
     LIBPATH += /usr/lib/w32api
-    ifneq (,$(call find_lib,winmm􀀌􀀋))
+    ifneq (,$(call find_lib,winmm))
       OS_CCDEFS += -DHAVE_WINMM
       OS_LDFLAGS += -lwinmm
     endif


### PR DESCRIPTION
Somehow commit 2c89387 added some junk characters at the end of the winmm library name; this PR fixes that