### PR TITLE
FIO: Add a global variable that indicates the normal host path separator

### DIFF
--- a/sim_fio.c
+++ b/sim_fio.c
@@ -78,6 +78,13 @@ t_bool sim_end;                     /* TRUE = little endian, FALSE = big endian 
 t_bool sim_taddr_64;                /* t_addr is > 32b and Large File Support available */
 t_bool sim_toffset_64;              /* Large File (>2GB) file I/O Support available */
 
+const char sim_file_path_separator  /* Platform specific value \ or / as appropriate */
+#if defined (_WIN32)
+                              = '\\';
+#else
+                              = '/';
+#endif
+
 #if defined(fprintf)                /* Make sure to only use the C rtl stream I/O routines */
 #undef fprintf
 #undef fputs

--- a/sim_fio.h
+++ b/sim_fio.h
@@ -105,6 +105,8 @@ extern t_bool sim_taddr_64;         /* t_addr is > 32b and Large File Support av
 extern t_bool sim_toffset_64;       /* Large File (>2GB) file I/O support */
 extern t_bool sim_end;              /* TRUE = little endian, FALSE = big endian */
 
+extern const char sim_file_path_separator;  /* Platform specific value \ or / as appropriate */
+
 char *sim_trim_endspc (char *cptr);
 int sim_isspace (int c);
 #ifdef isspace


### PR DESCRIPTION
This avoids the potential need for platform specific #ifdef blocks in simulator code which need/have awareness of host system file paths.