### PR TITLE
AltairZ80: m68k: Avoid buffer overflow detected by gcc 9.4.0.

### DIFF
--- a/AltairZ80/m68k/m68kdasm.c
+++ b/AltairZ80/m68k/m68kdasm.c
@@ -3773,7 +3773,7 @@ unsigned int m68k_disassemble(char* str_buff, unsigned int pc, unsigned int cpu_
 
 char* m68ki_disassemble_quick(unsigned int pc, unsigned int cpu_type)
 {
-    static char buff[100];
+    static char buff[200];
     buff[0] = 0;
     m68k_disassemble(buff, pc, cpu_type);
     return buff;


### PR DESCRIPTION
## AltairZ80: m68k: Avoid buffer overflow detected by gcc 9.4.0.

### Summary
Avoid static buffer overflow detected by gcc 9.4.0 on Ubuntu 20.04.  Thanks @markpizz for pointing this out.

### Compiled with:

* VS 2022 17.6.3 - CMake
* MacOS (x64) clang-1400.0.29.202
* Linux gcc 10.2.1

### [Automated tests](https://github.com/hharte/altairz80-tests):
SIMH running on Windows, Linux (ARM), MacOS (x64):

[CompuPro CP/M-80](https://schorn.ch/cpm/zip/cpm86.zip)
[CompuPro CP/M-86](https://schorn.ch/cpm/zip/cpm86.zip)
[SCP 86-DOS](https://schorn.ch/cpm/zip/86dos.zip)
[MS-DOS 2.11](https://github.com/hharte/altairz80-packages/tree/main/msdos211_test) - Builds [MS-DOS 2.11 from source](https://github.com/hharte/ms-dos).
[CompuPro CP/M-68K v1.3](https://github.com/hharte/altairz80-packages/tree/main/ccpm68k13) (68000 and 68010 versions)
[CP/M-68K v1.2](https://schorn.ch/cpm/zip/cpm68k.zip)
[Advanced Digital Super-Six CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm2)
[Advanced Digital Super-Six CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm3)
[DIGITEX CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm2)
[DIGITEX CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm3)
[DIGITEX OASIS multi-user version 5.6](https://github.com/open-simh/simh/pull/github.com/hharte/altairz80-packages/tree/main/dig_oasis56)
[MultiStar: IBC OASIS multi-user version 5.6](https://github.com/hharte/altairz80-packages/blob/main/ibcmcc_oasis56)
[MegaStar: IBC OASIS multi-user version 5.6](https://github.com/hharte/altairz80-packages/blob/main/ibcscc_oasis56)
[CP/M-80 (Altair)](https://schorn.ch/cpm/zip/cpm2.zip) ZEXALL Z80 instruction set test.
[CP/M 3 (Altair)](https://schorn.ch/cpm/zip/cpm3.zip) Banked Memory Test.

FYI, @psco