### PR TITLE
appveyor.yml build, dep lib version number updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,14 +13,15 @@ environment:
     ## The matrix is ordered by relative popularity/priority:
     ##-
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-      SIMH_BUILD_FLAVOR: ninja
-
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       SIMH_BUILD_FLAVOR: vs2022
+      ## Static library support available in this vcpkg install.
+      VCPKG_ROOT: C:\Tools\vcpkg
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       SIMH_BUILD_FLAVOR: vs2019
+      ## Static library support available in this vcpkg install.
+      VCPKG_ROOT: C:\Tools\vcpkg
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       SIMH_BUILD_FLAVOR: vs2017
@@ -28,32 +29,39 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       SIMH_BUILD_FLAVOR: vs2022-xp
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      SIMH_BUILD_FLAVOR: vs2019-xp
+    ## These Appveyor VM images exist, aren't strictly needed to build XP-compatible
+    ## executables.
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      SIMH_BUILD_FLAVOR: vs2017-xp
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    #   SIMH_BUILD_FLAVOR: vs2019-xp
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      SIMH_BUILD_FLAVOR: vs2015
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   SIMH_BUILD_FLAVOR: vs2017-xp
+
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   SIMH_BUILD_FLAVOR: vs2015
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      SIMH_BUILD_FLAVOR: ninja
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       SIMH_BUILD_FLAVOR: unix
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
-      SIMH_BUILD_FLAVOR: unix
+    ## Older image -- still needed?
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
+    #   SIMH_BUILD_FLAVOR: unix
 
     ## These images have cmake 3.12, which is too old. Could build if
     ## cmake were upgraded in the image in the before_build stanza, but
-    ## that subverts the purpose of the image.
+    ## that subverts the image's purpose.
 
     # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
     #   SIMH_BUILD_FLAVOR: vs2013
     #
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2012
     #   SIMH_BUILD_FLAVOR: vs2012
     #
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2008
     #   SIMH_BUILD_FLAVOR: vs2008
     
     ## - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
@@ -89,11 +97,10 @@ build:
   verbosity: minimal
 
 before_build:
-  - ps: |
-      if ($isWindows) {
-        if (${env:SIMH_BUILD_FLAVOR} -eq "ninja") { choco install ninja; }
-        if (!(Test-Path -Path cmake\dependencies)) { New-Item -ItemType Directory -Path cmake\dependencies }
-      }
+  - cmd: |
+      if "%SIMH_BUILD_FLAVOR%"=="ninja" ( choco install ninja )
+      if not exist "cmake\dependencies" ( mkdir "cmake\dependencies" )
+
   - sh: |
       case "${APPVEYOR_BUILD_WORKER_IMAGE}" in
       Ubuntu*)
@@ -112,17 +119,18 @@ before_build:
       esac
 
 build_script:
-  # Run the cmake-builder script all the way through: generate, build, test.
-  - ps: |
-      if ($isWindows) {
-          $ErrorActionPreference="Stop"
-          $WarningPreference="Continue"
-        if (!([string]::IsNullOrEmpty($env:MINGW))) { $env:PATH=$(@(${env:MINGW}, ${env:PATH}) -join ";"); };
-        cmake\cmake-builder.ps1 `
-            -flavor ${env:SIMH_BUILD_FLAVOR} `
-            -config ${env:CONFIGURATION} `
-            -lto -parallel -clean -notest -noinstall -verbose
-      }
+  ## Need to use cmd, per Appveyor support. PowerShell has issues with output.
+  ## Specifically, when CMake prints the "old CMake version, won't CPack" warning,
+  ## Appveyor terminates the build injudiciously. The workaround is cmd.
+  ##
+  ## LTO works reliably on VS 2022 and 2019. Hangs while building SEL32 on VS 2017.
+  - cmd: |
+      SETLOCAL EnableExtensions
+      if not "%MINGW%"=="" ( set "PATH=%MINGW%;%PATH%" )
+      if "%SIMH_BUILD_FLAVOR%"=="vs2022" set LTO=-lto
+      if "%SIMH_BUILD_FLAVOR%"=="vs2019" set LTO=-lto
+      powershell -File .\cmake\cmake-builder.ps1 -flavor %SIMH_BUILD_FLAVOR% -config %CONFIGURATION% %LTO% -parallel -clean -notest -noinstall -verbose
+
   - sh: |
       case "${APPVEYOR_BUILD_WORKER_IMAGE}" in
       Ubuntu1604)
@@ -137,11 +145,15 @@ build_script:
           --verbose --parallel --clean --notest --noinstall
 
 test_script:
-  - ps: |
-      if ($isWindows) {
-        Write-Output "cmake\cmake-builder.ps1 -testonly -config ${env:CONFIGURATION} -flavor ${env:SIMH_BUILD_FLAVOR}"
-        cmake\cmake-builder.ps1 -testonly -config ${env:CONFIGURATION} -flavor ${env:SIMH_BUILD_FLAVOR}
-      }
+  #   - ps: |
+  #       if ($isWindows) {
+  #         Write-Output "cmake\cmake-builder.ps1 -testonly -config ${env:CONFIGURATION} -flavor ${env:SIMH_BUILD_FLAVOR}"
+  #         cmake\cmake-builder.ps1 -testonly -config ${env:CONFIGURATION} -flavor ${env:SIMH_BUILD_FLAVOR}
+  #       }
+
+  - cmd: |
+      powershell -File .\cmake\cmake-builder.ps1 -flavor %SIMH_BUILD_FLAVOR% -config %CONFIGURATION% -testonly
+
   - sh: |
       cmake/cmake-builder.sh --testonly --config ${CONFIGURATION} --flavor ${SIMH_BUILD_FLAVOR}
 

--- a/cmake/dep-locate.cmake
+++ b/cmake/dep-locate.cmake
@@ -122,21 +122,21 @@ list(APPEND PCRE_SOURCE_URL
     "https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.zip/download?use_mirror=freefr"
     "https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.zip/download?use_mirror=master"
 )
-set(PNG_SOURCE_URL      "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.39.tar.gz")
+set(PNG_SOURCE_URL      "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.40.tar.gz")
 ## Freetype also needs multiple URLs to chase a working mirror:
 list(APPEND FREETYPE_SOURCE_URL
-    "https://github.com/freetype/freetype/archive/refs/tags/VER-2-12-1.zip"
-    "https://sourceforge.net/projects/freetype/files/freetype2/2.12.1/ft2121.zip/download?use_mirror=cytranet"
-    "https://sourceforge.net/projects/freetype/files/freetype2/2.12.1/ft2121.zip/download?use_mirror=phoenixnap"
-    "https://sourceforge.net/projects/freetype/files/freetype2/2.12.1/ft2121.zip/download?use_mirror=versaweb"
-    "https://sourceforge.net/projects/freetype/files/freetype2/2.12.1/ft2121.zip/download?use_mirror=netactuate"
-    "https://sourceforge.net/projects/freetype/files/freetype2/2.12.1/ft2121.zip/download?use_mirror=cfhcable"
-    "https://sourceforge.net/projects/freetype/files/freetype2/2.12.1/ft2121.zip/download?use_mirror=freefr"
-    "https://sourceforge.net/projects/freetype/files/freetype2/2.12.1/ft2121.zip/download?use_mirror=master"
-    "https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.xz"
-    "https://gitlab.freedesktop.org/freetype/freetype/-/archive/VER-2-12-1/freetype-VER-2-12-1.zip"
+    "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-0.zip"
+    "https://sourceforge.net/projects/freetype/files/freetype2/2.13.1/ft2131.zip/download?use_mirror=cytranet"
+    "https://sourceforge.net/projects/freetype/files/freetype2/2.13.1/ft2131.zip/download?use_mirror=phoenixnap"
+    "https://sourceforge.net/projects/freetype/files/freetype2/2.13.1/ft2131.zip/download?use_mirror=versaweb"
+    "https://sourceforge.net/projects/freetype/files/freetype2/2.13.1/ft2131.zip/download?use_mirror=netactuate"
+    "https://sourceforge.net/projects/freetype/files/freetype2/2.13.1/ft2131.zip/download?use_mirror=cfhcable"
+    "https://sourceforge.net/projects/freetype/files/freetype2/2.13.1/ft2131.zip/download?use_mirror=freefr"
+    "https://sourceforge.net/projects/freetype/files/freetype2/2.13.1/ft2131.zip/download?use_mirror=master"
+    "https://download.savannah.gnu.org/releases/freetype/freetype-2.13.1.tar.xz"
+    "https://gitlab.freedesktop.org/freetype/freetype/-/archive/VER-2-13-0/freetype-VER-2-13-0.zip"
 )
-set(SDL2_SOURCE_URL     "https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.26.3.zip")
+set(SDL2_SOURCE_URL     "https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.28.1.zip")
 set(SDL2_TTF_SOURCE_URL "https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-2.20.2.zip")
 
 ## Need to build ZLIB for both PCRE and libpng16:


### PR DESCRIPTION
- Give appveyor.yml some much needed attention. Specifically, work around the CMake build termination when the issuing the "CMake is too old to produce packages" warning message. There's something funky with how Appveyor's runtime interacts with PowerShell and warning/diagnostic output ends up terminating builds unexpectedly. Appveyor's technical support says to write the CI/CD script using the old DOS CMD interpreter, not PowerShell.

- Cut down the number of builds. Older Visual Studio VM images are still in the appveyor.yml matrix, just commented out.

- dep-locate.cmake: Update dependency library version numbers to reflect recent releases for libpng16, SDL and SDL_ttf. This affects the XP "legacy" CMake builds on Github CI/CD, Appveyor's VS 2017 and earlier VM images that build the minimal SIMH dependency library support (i.e., environments where vcpkg is known not to work.)