### PR TITLE
DISK: Fix VHD to Ensure that the CHS capacity exceeds the disk length

### DIFF
--- a/sim_disk.c
+++ b/sim_disk.c
@@ -5758,7 +5758,7 @@ if (1) { /* CHS Calculation */
             cylinderTimesHeads = totalSectors / sectorsPerTrack;
             }
         }
-    cylinders = cylinderTimesHeads / heads;
+    cylinders = (totalSectors + sectorsPerTrack * heads - 1) / (sectorsPerTrack * heads);
     Footer.DiskGeometry = NtoHl ((cylinders<<16)|(heads<<8)|sectorsPerTrack);
     }
 Footer.Checksum = NtoHl (CalculateVhdFooterChecksum(&Footer, sizeof(Footer)));


### PR DESCRIPTION
If the total sectors exceeds 127Gb this is not possible, but normal simh disks are smaller and the largest user settable size via RAUSER is just under 1Tb.  The excessive size case (>127Gb) will have a CHS of 0xFFFF10FF.

simh never cares about the CHS Disk Geometry value in the VHD footer data structure, but other applications which do care about the CHS value using the previously incorrect value as the capacity of the disk even though the Current Size indicated in the footer may have been larger.

Fixes #287 