### PR TITLE
TX-0: Execute pad and cry separately

### DIFF
--- a/TX-0/tx0_cpu.c
+++ b/TX-0/tx0_cpu.c
@@ -104,7 +104,6 @@ from "A Functional Description of the TX-0 Computer" Oct, 1958
    5. Bugs, limitations, and known issues:
         o There is a bug in the 1961 instruction set simulation, which causes the
           mouse maze program's searching algorithm to fail.
-        o The CRY micro-order is not implemented.
         o The instruction timing (ie, sim_interval) is not accurate, so implementing a
           timing-critical I/O device like the Magtape would require this to be added first.
         o PCQ and History do not work.
@@ -150,6 +149,8 @@ In addtion, many of the operate-class micro-orders changed.
   orb  --- --- --- --- --- 101  1.3 Or LR into MBR
   lmb  --- --- --- --- --- 01x  1.4 Tranfer LR contents to MBR
   mbx  --- --- --- --- --- 0x1  1.8 Transfer MBR contents to XR
+
+See TX-0 memo M-5001-19 for a simple formula for cry, used in the code below.
 */
 #include "tx0_defs.h"
 
@@ -932,20 +933,10 @@ t_stat sim_instr (void)
             }
 
             if (op & OPR_PAD) { /* 1.5 Partial Add (XOR): AC = MBR ^ AC */
-                if (op & OPR_CRY) { /* 1.7 */
-                    TRACE_PRINT(ORD_MSG, ("[%06o] PAD+CRY: AC=%06o, MBR=%06o = ", PC-1, AC, MBR));
-                    AC = AC + MBR;
-                    if (AC > DMASK) {
-                        AC += 1;
-                    }
-                    AC &= DMASK;
-                    TRACE_PRINT(ORD_MSG, ("%06o\n", AC));
-                } else {
-                    TRACE_PRINT(ORD_MSG, ("[%06o] PAD: AC=%06o, MBR=%06o\n", PC-1, AC, MBR)); 
-                    AC = AC ^ MBR;
-                    AC &= DMASK;
-                    TRACE_PRINT(ORD_MSG, ("[%06o] PAD: Check: AC=%06o\n", PC-1, AC)); 
-                }
+                TRACE_PRINT(ORD_MSG, ("[%06o] PAD: AC=%06o, MBR=%06o = ", PC-1, AC, MBR));
+                AC = AC ^ MBR;
+                AC &= DMASK;
+                TRACE_PRINT(ORD_MSG, ("%06o\n", AC));
                 inst_ctr.pad++;
             }
 
@@ -968,11 +959,16 @@ t_stat sim_instr (void)
             }
 
             if (op & OPR_CRY) { /* 1.7 */
-                if (op & OPR_PAD) {
-                } else {
-                    TRACE_PRINT(ERROR_MSG, ("[%06o] CRY: TODO: AC=%06o\n", PC-1, AC)); 
-                    inst_ctr.cry++;
+                TRACE_PRINT(ORD_MSG, ("[%06o] CRY: AC=%06o, MBR=%06o = ", PC-1, AC, MBR));
+                AC = AC ^ MBR;
+                AC &= DMASK;
+                AC = AC + MBR;
+                if (AC > DMASK) {
+                    AC += 1;
                 }
+                AC &= DMASK;
+                TRACE_PRINT(ORD_MSG, ("%06o\n", AC));
+                inst_ctr.cry++;
             }
 
             if ((op & OPR_MBX_MASK) == OPR_MBX) { /* 1.8    MBR[5:17] -> XR[5:17], MBR[0] -> XR[4] */
@@ -1444,30 +1440,24 @@ t_stat sim_opr_orig(int32 op)
     }
 
     if (op & OOPR_PAD) {    /* 1.5 Partial Add (XOR): AC = MBR ^ AC */
-        if (op & OOPR_CRY) {    /* 1.7 */
-            TRACE_PRINT(ORD_MSG, ("[%06o] PAD+CRY: AC=%06o, MBR=%06o = ", PC-1, AC, MBR));
-            AC = AC + MBR;
-            if (AC & 01000000) {
-                AC += 1;
-            }
-            AC &= DMASK;
-            TRACE_PRINT(ORD_MSG, ("%06o\n", AC));
-            inst_ctr.cry++;
-        } else {
-            TRACE_PRINT(ORD_MSG, ("[%06o] PAD: AC=%06o, MBR=%06o\n", PC-1, AC, MBR)); 
-            AC = AC ^ MBR;
-            AC &= DMASK;
-            TRACE_PRINT(ORD_MSG, ("[%06o] PAD: Check: AC=%06o\n", PC-1, AC)); 
-        }
+        TRACE_PRINT(ORD_MSG, ("[%06o] PAD: AC=%06o, MBR=%06o = ", PC-1, AC, MBR));
+        AC = AC ^ MBR;
+        AC &= DMASK;
+        TRACE_PRINT(ORD_MSG, ("%06o\n", AC));
         inst_ctr.pad++;
     }
 
     if (op & OOPR_CRY) {    /* 1.7 */
-        if (op & OOPR_PAD) {
-        } else {
-            TRACE_PRINT(ERROR_MSG, ("[%06o] CRY: TODO: AC=%06o\n", PC-1, AC)); 
-            inst_ctr.cry++;
+        TRACE_PRINT(ORD_MSG, ("[%06o] CRY: AC=%06o, MBR=%06o = ", PC-1, AC, MBR));
+        AC = AC ^ MBR;
+        AC &= DMASK;
+        AC = AC + MBR;
+        if (AC > DMASK) {
+            AC += 1;
         }
+        AC &= DMASK;
+        TRACE_PRINT(ORD_MSG, ("%06o\n", AC));
+        inst_ctr.cry++;
     }
 
     if ((op & OOPR_HLT) == OOPR_HLT) {   /* hlt  1.8 Halt the computer */


### PR DESCRIPTION
Before, when the simulator decoded pad, it handled pad without cry and pad with cry. When it decoded cry, it printed a "TO DO" message.

http://bitsavers.org/pdf/mit/tx-0/memos/M-5001-19_macros_Apr60.pdf derives a simple algorithm for cry. Implement that, remove the test for cry from the pad code, and reformat the debug messages.

The same change appears in sim_instr and sim_opr_orig.