### PR TITLE
TX-0: Stop ptp_svc from setting the ios bit; sim_instr never clears it and simulation loops.

### DIFF
--- a/TX-0/tx0_stddev.c
+++ b/TX-0/tx0_stddev.c
@@ -524,7 +524,6 @@ int32 ptp (int32 inst, int32 dev, int32 dat)
 
 t_stat ptp_svc (UNIT *uptr)
 {
-    ios = 1;                                            /* restart */
     iosta = iosta | IOS_PTP;                                /* set flag */
     if ((uptr->flags & UNIT_ATT) == 0)                      /* not attached? */
         return SCPE_UNATT;


### PR DESCRIPTION
The CPU-to-device routines and device service routines need a redesign. In the meantime, this quick patch makes tape punching possible.