### PR TITLE
TX-0: Make ^E work in readin mode.

### DIFF
--- a/TX-0/tx0_cpu.c
+++ b/TX-0/tx0_cpu.c
@@ -304,6 +304,8 @@ extern int32 drm (int32 inst, int32 dev, int32 dat);
 extern int32 dpy (int32 ac);
 #endif
 
+extern UNIT petr_unit;
+
 /* CPU data structures
 
    cpu_dev      CPU device descriptor
@@ -470,14 +472,20 @@ t_stat sim_instr (void)
             break;
         }
 
+        sim_interval = sim_interval - 1;
+
         if (ios) {
             TRACE_PRINT(ERROR_MSG, ("I/O Stop - Waiting...\n"));
-            continue;
+            continue; /* Don't execute test/readin/normal mode */
         }
 
         /* Handle Instruction Execution in TEST and READIN modes */
         if (mode_tst) { /* Test Mode / Readin mode */
             if (mode_rdin) { /* Readin Mode */
+
+                if ((petr_unit.flags & UNIT_ATT) == 0)
+                    return SCPE_UNATT;
+
                 reason = SCPE_OK;   /* Default is to continue reading, and transfer control when done. */
                 AC = petr(3,0,0);   /* Read three chars from tape into AC */
                 MAR = AC & AMASK;   /* Set memory address */
@@ -486,6 +494,7 @@ t_stat sim_instr (void)
                 if (!MEM_ADDR_OK(MAR)) {
                     TRACE_PRINT(ERROR_MSG, ("READIN: Tape address out of range.\n"));
                     reason = SCPE_FMT;
+                    break;
                 }
 
                 switch (IR) {
@@ -497,29 +506,29 @@ t_stat sim_instr (void)
                         break;
                     case 02:    /* Transfer Control (trn x) Start Execution */
                         PC = MAR;
-                        reason = SCPE_OK;   /* let SIMH start execution. */
                         TRACE_PRINT(READIN_MSG, ("READIN: trn %06o (Start Execution)\n", PC));
                         reason = cpu_set_mode(&cpu_unit, 0, NULL, NULL);
                         break;
                     case 01:    /* Transfer (add x) - Halt */
                         PC = MAR;
-                        reason = SCPE_STOP; /* let SIMH halt. */
                         TRACE_PRINT(READIN_MSG, ("READIN: add %06o (Halt)\n", PC));
                         reason = cpu_set_mode(&cpu_unit, 0, NULL, NULL);
+                        if (reason == SCPE_OK) reason = SCPE_STOP; /* let SIMH halt. */
                         break;
                     default:
                         reason = SCPE_IERR;
                         break;
                 }
-            } else if (mode_tst) {  /* Test mode not implemented yet. */
+                continue;  /* Don't fall into normal-mode processing. */
+            } else {  /* Test mode not implemented yet. */
                 TRACE_PRINT(ERROR_MSG, ("TEST Mode not implemented.\n"));
                 reason = SCPE_STOP;
-
-            } else {
-                TRACE_PRINT(ERROR_MSG, ("Invalid CPU mode.\n"));
-                reason = SCPE_IERR;
+                break;
             }
-            continue;   /* Proceed with next instruction */
+        } else if (mode_rdin) {
+            TRACE_PRINT(ERROR_MSG, ("Invalid CPU mode.\n"));
+            reason = SCPE_IERR;
+            break;
         }
 
         /* Fetch, decode instruction in NORMAL mode */
@@ -530,7 +539,6 @@ t_stat sim_instr (void)
         inst_class = IR >> 3;
         op = MBR & AMASK;
         y = MBR & YMASK;
-        sim_interval = sim_interval - 1;
 
         if ((cpu_unit.flags & UNIT_EXT_INST) == 0) {  /* Original instruction set */
             IR &= 030;

--- a/TX-0/tx0_stddev.c
+++ b/TX-0/tx0_stddev.c
@@ -414,6 +414,9 @@ t_stat petr_boot (int32 unitno, DEVICE *dptr)
     int32 addr, tdata;
 #endif /* SANITY_CHECK_TAPE */
 
+    if ((petr_unit.flags & UNIT_ATT) == 0)
+        return SCPE_UNATT;
+
     /* Switch to READIN mode. */
     cpu_set_mode(&cpu_unit, UNIT_MODE_READIN, NULL, NULL);
 #ifdef SANITY_CHECK_TAPE


### PR DESCRIPTION
sim_instr does not completely follow the outline in the SIMH v3
developer docs. It does not decrease sim_interval in readin mode.
Fixing this, I cleaned up some other things:

- Move the decrease of sim_interval to after the check for breakpoints,
  but before the check for ios. This ensures that sim_interval will
  decrease any time an instruction executes in normal mode, or readin
  mode executes, or ios is set and the CPU is waiting for ios to clear.
  (Except the CPU should be clearing ios itself, not waiting for ios to
  clear, but that fix requires a complete redesign of the I/O routines
  and belongs in another branch.)
- Correctly handle all four combinations of mod_tst and mod_rdin.
- When changing from readin mode to normal mode, if cpu_set_mode returns
  an error, stop with the same error. If cpu_set_mode returns SCPE_OK,
  either stop or continue execution, depending on the word read from tape.
- Check that PETR is attached when booting or reading in tapes. If not,
  return SCPE_UNATT. This prevents reading from standard input.

Overall control structure inside the while (reason == 0) loop:

- When stopping due to an error, break out of the while loop where
  possible.
- After handling "ios is set", continue, don't run readin/test/normal-
  mode code.
- After handling one readin operation, if the code didn't break out
  of the while loop, continue, don't run normal-mode code.