### PR TITLE
SCP: Fix correctly loading simh.ini when user HOME not defined

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -2932,6 +2932,8 @@ if (docmdp) {
         snprintf(nbuf, sizeof (nbuf), "\"%s%s%ssimh.ini\"", cptr2 ? cptr2 : "", cptr, strchr (cptr, '/') ? "/" : "\\");
         stat = docmdp->action (-1, nbuf);                   /* simh.ini proc cmd file */
         }
+    else
+        stat = SCPE_OPENERR;
     if (SCPE_BARE_STATUS(stat) == SCPE_OPENERR)
         stat = docmdp->action (-1, "simh.ini");             /* simh.ini proc cmd file */
     if (*cbuf)                                              /* cmd file arg? */


### PR DESCRIPTION
When loading `simh.ini` if none of the HOME directory environment is set, a stale `stat` value is used in decision whether to load `simh.ini` from the current directory.

This patch fixes this issue (so the local `simh.ini` will be tried).
