### PR TITLE
PDP11: 11/70 read-only registers must not return NXM on write

### DIFF
--- a/PDP11/pdp11_cpumod.c
+++ b/PDP11/pdp11_cpumod.c
@@ -685,6 +685,9 @@ return SCPE_NXM;                                        /* unimplemented */
 t_stat CPU70_wr (int32 data, int32 pa, int32 access)
 {
 switch ((pa >> 1) & 017) {                              /* decode pa<4:1> */
+    case 000:
+    case 001:
+        return SCPE_OK;                                 /* error addr */
 
     case 002:                                           /* MEMERR */
         ODD_SHF (data);
@@ -706,6 +709,9 @@ switch ((pa >> 1) & 017) {                              /* decode pa<4:1> */
         return SCPE_OK;
 
     case 011:                                           /* high size */
+        return SCPE_OK;
+
+    case 012:                                           /* system ID */
         return SCPE_OK;
 
     case 013:                                           /* CPUERR */


### PR DESCRIPTION
`17 777 740` - `17 777 742`, read-only error address registers, and `17 777 764`, a read-only System ID register,

are not handled in the `CPU70_wr()` routine, which means for these addresses the routine returns `NXM`, which then translates to "bus timeout" (no response to address), and then, as a result, trap to vector 4.

That is incorrect, IMO.

These locations are read-only yet the address gets decoded, and even though writing does not have any effect, the write routine for these addresses should return `SCPE_OK`.

This patch fixes the issue.

Background:

I was trying to run DEC/X11 diagnostic and, instead of getting the "`CMD>`" prompt, when started it was throwing a lot of VECTOR 4 errors for the following instruction, endlessly (only the simulator stop and reboot would help):
```
**  SYSTEM ERROR  **
 
VECTOR   PC+      ADDR     PSW      SP     ERCT
000004  010760  00010760  000044  002312  00001
 
RUNTIME:
 
11/70 ERROR LOG
```
```
010754  CLR @1220
010760  CLR @1222
```
```
001220 .WORD 177740
001222 .WORD 177742
```
`177740-42` is an 11/70's error address register.  Obviously, DEC/X11 was checking that the register exists (because 11/70 was a declared configuration), but the address appeared "unresponsive".

When I added a NO-OP handling for both `177740` and `177742` in simh, the DEC/X11 diagnostics showed me the prompt and I was able to (successfully) test the simulated hardware.  I suppose that returning `NXM` for an address that actually exists but read-only, is not the correct behavior, and the fix just proves it.  Going a bit further, and using the same logic, I figured out that yet another 11/70's register, the System ID register, was not handled in the write routine (same, returning `NXM`) so I added the NO-OP handling for that, too.  With this change, it looks like all the special 11/70 registers (per the Handbook that I have) are covered in the simh code now, as "recognized addresses".
