### PR TITLE
SCP: SOCK: Increase backlog in the listen() syscall

### DIFF
--- a/sim_sock.c
+++ b/sim_sock.c
@@ -1088,7 +1088,7 @@ if (!(opt_flags & SIM_SOCK_OPT_BLOCKING)) {
     if (sta == SOCKET_ERROR)                            /* fcntl error? */
         return sim_err_sock (newsock, "setnonblock");
     }
-sta = listen (newsock, 1);                              /* listen on socket */
+sta = listen (newsock, 64);                             /* listen on socket */
 if (sta == SOCKET_ERROR)                                /* listen error? */
     return sim_err_sock (newsock, "listen");
 return newsock;                                         /* got it! */


### PR DESCRIPTION
The currently used backlog of (1) effectively disables any two or more simultanueously incoming connections at the kernel level, because the backlog parameter only allows 1 such connection.  Yet since terminal multiplexers can handle tens of clients, it's not technically impossible to have more than one incoming request to be received at any particular moment (for two different "lines").  A reasonable backlog of more than 1 safeguards that the "extra" connections won't be refused outright, and postpones that decision to be made by simh (not the kernel) -- for example, when, say, all multiplexer lines are busy, with an explanation (which states so) rather than just the infamous "Connection reset by peer" (effected by the kernel reset).

This patch increases the backlog to 64.