### PR TITLE
Remove files symlinked to /Library

### DIFF
--- a/.github/workflows/cmake-builds.yml
+++ b/.github/workflows/cmake-builds.yml
@@ -46,6 +46,12 @@ jobs:
         os: [macos-12, macos-11]
     steps:
     - uses: actions/checkout@v3
+    ## For some reason, the macos-11 image has symlinks to /Library in /usr/local/bin
+    - name: Clean /usr/local/bin symlinks
+      run: |
+        for f in $(find /usr/local/bin -type l -print); do \
+           (readlink $f | grep -q -s "/Library") && echo Removing "$f" && rm -f "$f"; \
+         done || exit 0
     - name: Install dependencies
       run: |
         sh -ex .travis/deps.sh osx


### PR DESCRIPTION
Clean up /usr/local/bin symlinks to /Library that prevents "brew update" from succeeding. The macOS 11 image has Python binaries symlinked into /usr/local/bin from /Library, which consequently sends `brew` into a build failure.

Not specific to the Github macos-11 image, inserted for macOS generally.

(Nudge: Please merge PR #286 and #149 as well.)