### PR TITLE
DISK: Do not allow to emit any "footers"

### DIFF
--- a/sim_disk.c
+++ b/sim_disk.c
@@ -2439,6 +2439,8 @@ time_t now = time (NULL);
 t_offset total_sectors;
 t_offset highwater;
 
+return SCPE_OK;
+
 if ((dptr = find_dev_from_unit (uptr)) == NULL)
     return SCPE_NOATT;
 if (uptr->flags & UNIT_RO)
@@ -2501,6 +2503,8 @@ struct simh_disk_footer *f;
 t_offset total_sectors;
 t_offset highwater;
 t_offset footer_highwater;
+
+return SCPE_OK;
 
 if ((dptr = find_dev_from_unit (uptr)) == NULL)
     return SCPE_NOATT;


### PR DESCRIPTION
This is the initial iteration of cleaning up simh of appending the "footers" to disk images:  it does not allow to emit any new "footers", yet it does not change the behavior as to how any existing "footers" are treated internally.  Also, even though sim_disk.c currently builds the "footer" for any attached disk container, with this patch, it is only kept in-memory, and never gets written to (appended / updated) the actual container.

To address #13 

Any existing "footer" already in the disk image, can be dropped with the "ZAP" command, and with this patch, it won't get reinstated.