### PR TITLE
CMAKE: Python distutils obsoleted.

### DIFF
--- a/cmake/generate.py
+++ b/cmake/generate.py
@@ -22,7 +22,6 @@ import pprint
 import simgen.cmake_container as SCC
 import simgen.parse_makefile as SPM
 import simgen.packaging as SPKG
-## from simgen.text_file import TextFile
 
 
 def process_makefile(makefile_dir, debug=0):

--- a/cmake/simgen/parse_makefile.py
+++ b/cmake/simgen/parse_makefile.py
@@ -23,7 +23,9 @@ def parse_makefile(fn, g_vars=None, g_rules=None, g_actions=None):
     Collects all of the variable definitions, rules and actions associated with rules.
 
     """
-    from distutils.text_file import TextFile
+    ## Python 3.11 and onward dropped distuitls, so import our local copy.
+    from simgen.text_file import TextFile
+
     fp = TextFile(fn, strip_comments=1, skip_blanks=1, join_lines=1, errors="surrogateescape")
 
     if g_vars is None:

--- a/cmake/simgen/text_file.py
+++ b/cmake/simgen/text_file.py
@@ -2,12 +2,7 @@
 
 provides the TextFile class, which gives an interface to text files
 that (optionally) takes care of stripping comments, ignoring blank
-lines, and joining lines with backslashes.
-
-NOTE: This Python source code is adapted from the distutils module.
-Given that the future of distutils is uncertain, keep and maintain
-a local copy here.
-"""
+lines, and joining lines with backslashes."""
 
 import sys, io
 


### PR DESCRIPTION
Python 3.12 will not have the distutils package in the standard library. The TextFile class is particularly useful when reading [Mm]akefiles, and recreating its functionality would be painful.

Stash a local copy of the last version of distutils.text_file.py and use it. Do not rely on distutils being present or installed.