### PR TITLE
ALTAIRZ80: Don't sleep in SIO device if throttling

### DIFF
--- a/AltairZ80/altairz80_sio.c
+++ b/AltairZ80/altairz80_sio.c
@@ -744,9 +744,10 @@ static SIO_PORT_INFO lookupPortInfo(const int32 port, int32 *position) {
 }
 
 /* keyboard idle detection: sleep when feature enabled, no character available
-    (duty of caller) and operation not voided (e.g. when output is available) */
+    (duty of caller), operation not voided (e.g. when output is available),
+    and throttling is not enabled. */
 static void checkSleep(void) {
-    if (sio_unit.flags & UNIT_SIO_SLEEP) {
+    if (sio_unit.flags & UNIT_SIO_SLEEP && sim_throt_get_type() == SIM_THROT_NONE) {
         if (sleepAllowedCounter)
             sleepAllowedCounter--;
         else

--- a/sim_timer.c
+++ b/sim_timer.c
@@ -23,6 +23,7 @@
    used in advertising or otherwise to promote the sale, use or other dealings
    in this Software without prior written authorization from Robert M Supnik.
 
+   29-Dec-23    PAL     Added sim_throt_get_type
    27-Sep-22    RMS     Removed OS/2 and Mac "Classic" support
    01-Feb-21    JDB     Added cast for down-conversion
    22-May-17    RMS     Hacked for V4.0 CONST compatibility
@@ -2036,6 +2037,11 @@ switch (sim_throt_state) {
 
 sim_activate (uptr, sim_throt_wait);                    /* reschedule */
 return SCPE_OK;
+}
+
+/* Return throttle type */
+uint32 sim_throt_get_type (void) {
+    return sim_throt_type;
 }
 
 /* Clock assist activites */

--- a/sim_timer.h
+++ b/sim_timer.h
@@ -129,6 +129,7 @@ t_stat sim_clr_idle (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 t_stat sim_show_idle (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 void sim_throt_sched (void);
 void sim_throt_cancel (void);
+uint32 sim_throt_get_type (void);
 uint32 sim_os_msec (void);
 void sim_os_sleep (unsigned int sec);
 uint32 sim_os_ms_sleep (unsigned int msec);


### PR DESCRIPTION
SCP: Add sim_throt_get_type() function to return type of throttling or none.

When throttling is enabled, sleeping the host CPU skews SCP's internal timers. "SET SIO NOSLEEP" has been the work-around when using THROTTLE. This PR prevents sleeping if throttling is enabled without having to use NOSLEEP. SCP will perform host CPU sleeps.