### PR TITLE
SCP: Adjust timer calibrations if SET THROTTLE x/t type is enabled

### DIFF
--- a/sim_timer.c
+++ b/sim_timer.c
@@ -680,6 +680,7 @@ static void _rtcn_configure_calibrated_clock (int32 newtmr);
 static t_bool _sim_coschedule_cancel (UNIT *uptr);
 static t_bool _sim_wallclock_cancel (UNIT *uptr);
 static t_bool _sim_wallclock_is_active (UNIT *uptr);
+static void _sim_timer_adjust_cal(void);
 t_stat sim_timer_show_idle_mode (FILE* st, UNIT* uptr, int32 val, CONST void *  desc);
 
 
@@ -1753,9 +1754,10 @@ else {
         sim_throt_wait = sim_throt_val;
         }
     }
-if (sim_throt_type == SIM_THROT_SPC)    /* Set initial value while correct one is determined */
+if (sim_throt_type == SIM_THROT_SPC) {  /* Set initial value while correct one is determined */
     sim_throt_cps = (int32)((1000.0 * sim_throt_val) / (double)sim_throt_sleep_time);
-else
+    _sim_timer_adjust_cal();            /* adjust timer calibrations */
+} else
     sim_throt_cps = sim_precalibrate_ips;
 return SCPE_OK;
 }
@@ -1960,21 +1962,7 @@ switch (sim_throt_state) {
             sim_debug (DBG_THR, &sim_timer_dev, "sim_throt_svc() Throttle values a_cps = %f, d_cps = %f, wait = %d, sleep = %d ms\n", 
                                                 a_cps, d_cps, sim_throt_wait, sim_throt_sleep_time);
             sim_throt_cps = d_cps;                  /* save the desired rate */
-            /* Run through all timers and adjust the calibration for each */
-            /* one that is running to reflect the throttle rate */
-            for (tmr=0; tmr<=SIM_NTIMERS; tmr++) {
-                rtc = &rtcs[tmr];
-                if (rtc->hz) {                                      /* running? */
-                    rtc->currd = (int32)(sim_throt_cps / rtc->hz);/* use throttle calibration */
-                    rtc->ticks = rtc->hz - 1;                     /* force clock calibration on next tick */
-                    rtc->rtime = sim_throt_ms_start - 1000 + 1000/rtc->hz;/* adjust calibration parameters to reflect throttled rate */
-                    rtc->gtime = sim_throt_inst_start - sim_throt_cps + sim_throt_cps/rtc->hz;
-                    rtc->nxintv = 1000;
-                    rtc->based = rtc->currd;
-                    if (rtc->clock_unit)
-                        sim_activate_abs (rtc->clock_unit, rtc->currd);/* reschedule next tick */
-                    }
-                }
+	    _sim_timer_adjust_cal();                /* adjust timer calibrations */
             }
         break;
 
@@ -2036,6 +2024,30 @@ switch (sim_throt_state) {
 
 sim_activate (uptr, sim_throt_wait);                    /* reschedule */
 return SCPE_OK;
+}
+
+/* Run through all timers and adjust the calibration for each */
+/* one that is running to reflect the throttle rate */
+static void _sim_timer_adjust_cal(void)
+{
+    int32 tmr;
+    RTC *rtc = NULL;
+
+    for (tmr=0; tmr<=SIM_NTIMERS; tmr++) {
+        rtc = &rtcs[tmr];
+
+        if (rtc->hz) {                                      /* running? */
+            rtc->currd = (int32)(sim_throt_cps / rtc->hz);/* use throttle calibration */
+            rtc->ticks = rtc->hz - 1;                     /* force clock calibration on next tick */
+            rtc->rtime = sim_throt_ms_start - 1000 + 1000/rtc->hz;/* adjust calibration parameters to reflect throttled rate */
+            rtc->gtime = sim_throt_inst_start - sim_throt_cps + sim_throt_cps/rtc->hz;
+            rtc->nxintv = 1000;
+            rtc->based = rtc->currd;
+
+            if (rtc->clock_unit)
+                sim_activate_abs (rtc->clock_unit, rtc->currd);/* reschedule next tick */
+        }
+    }
 }
 
 /* Clock assist activites */


### PR DESCRIPTION
SCP doesn't initially adjust timer calibrations if SET THROTTLE x/t type is enabled causing large delays in event dispatches. This PR runs the timers through the same calibration adjustment loop as other throttle types.