### PR TITLE
ETHER: Make sure SET NOASYNC is effective for Ethernet devices

### DIFF
--- a/VAX/vax_xs.c
+++ b/VAX/vax_xs.c
@@ -130,7 +130,7 @@ DEVICE xs_dev = {
     1, DEV_RDX, 20, 1, DEV_RDX, 8,
     NULL, NULL, &xs_reset,
     NULL, &xs_attach, &xs_detach,
-    &xs_dib, DEV_DEBUG | XS_FLAGS, 0,
+    &xs_dib, DEV_DEBUG | XS_FLAGS | DEV_ETHER, 0,
     xs_debug, NULL, NULL, &xs_help, NULL, NULL,
     &xs_description
     };

--- a/scp.c
+++ b/scp.c
@@ -5760,6 +5760,16 @@ if (cptr && (*cptr != 0))                               /* now eol? */
 #ifdef SIM_ASYNCH_IO
 if (flag == sim_asynch_enabled)                         /* already set correctly? */
     return SCPE_OK;
+if (1) {
+    uint32 i;
+    DEVICE *dptr;
+
+    for (i = 1; (dptr = sim_devices[i]) != NULL; i++) { /* flush attached files */
+        if ((DEV_TYPE(dptr) == DEV_ETHER) &&
+            (dptr->units->flags & UNIT_ATT))
+            return sim_messagef (SCPE_ALATT, "Can't change asynch mode with %s device attached\n", dptr->name);
+        }
+    }
 sim_asynch_enabled = flag;
 tmxr_change_async ();
 sim_timer_change_asynch ();

--- a/sim_ether.c
+++ b/sim_ether.c
@@ -2177,6 +2177,10 @@ return NULL;
 }
 #endif
 
+/* eth_set_async 
+ *
+ * Turn on reciever processing which can be either asynchronous or polled 
+ */
 t_stat eth_set_async (ETH_DEV *dev, int latency)
 {
 #if !defined(USE_READER_THREAD) || !defined(SIM_ASYNCH_IO)
@@ -2186,7 +2190,7 @@ return sim_messagef (SCPE_NOFNC, "%s", msg);
 #else
 int wakeup_needed;
 
-dev->asynch_io = 1;
+dev->asynch_io = sim_asynch_enabled;
 dev->asynch_io_latency = latency;
 pthread_mutex_lock (&dev->lock);
 wakeup_needed = (dev->read_queue.count != 0);
@@ -2199,6 +2203,10 @@ if (wakeup_needed) {
 return SCPE_OK;
 }
 
+/* eth_clr_async 
+ *
+ * Turn off reciever processing
+ */
 t_stat eth_clr_async (ETH_DEV *dev)
 {
 #if !defined(USE_READER_THREAD) || !defined(SIM_ASYNCH_IO)


### PR DESCRIPTION
SET NOASYNC is intended to disable asynchronous threads from interacting with the simulator event system.

The only cases where there asynchronous threads are:
1) Disks which are designed for asynchronous support using sim_disk.  The only case is the MSCP controller implemented by pdp11_rq (Device name RQ).
2) Tapes which are designed for asynchronous support using sim_tape.  The only case is the TMSCP controller implemented by pdp11_tq (Device name TQ).
3) Devices which use sim_ether to interface with Ethernet networks.  There are a number of these cases.

Prior to this change, SET NOASYNC only actually affected the RQ and TQ devices and had no effect on Ethernet devices.