### PR TITLE
PDP8: Fix missing clock pre-calibration instruction set due to typo

### DIFF
--- a/PDP8/pdp8_cpu.c
+++ b/PDP8/pdp8_cpu.c
@@ -1379,8 +1379,8 @@ return reason;
  */
 
 static const char *pdp8_clock_precalibrate_commands[] = {
-    "106 100"
-    "-m 100 MQL MQA"
+    "106 100",
+    "-m 100 MQL MQA",
     "-m 101 ISZ 112",
     "-m 102 JMP I 106",
     "-m 103 JMP I 106",


### PR DESCRIPTION
Fix suggested by David Gesswein in #342