### PR TITLE
AltairZ80: CPU changes no longer remove device memory maps

### DIFF
--- a/AltairZ80/altairz80_cpu.c
+++ b/AltairZ80/altairz80_cpu.c
@@ -6704,10 +6704,14 @@ static void cpu_clear(void) {
     uint32 i;
     for (i = 0; i < MAXMEMORY; i++)
         M[i] = 0;
-    for (i = 0; i < (MAXMEMORY >> LOG2PAGESIZE); i++)
-        mmu_table[i] = RAM_PAGE;
-    for (i = (MEMORYSIZE >> LOG2PAGESIZE); i < (MAXMEMORY >> LOG2PAGESIZE); i++)
-        mmu_table[i] = EMPTY_PAGE;
+    for (i = 0; i < (MAXMEMORY >> LOG2PAGESIZE); i++) {
+        if (!mmu_table[i].routine)
+            mmu_table[i] = RAM_PAGE;
+    }
+    for (i = (MEMORYSIZE >> LOG2PAGESIZE); i < (MAXMEMORY >> LOG2PAGESIZE); i++) {
+        if (!mmu_table[i].routine)
+            mmu_table[i] = EMPTY_PAGE;
+    }
     if (cpu_unit.flags & UNIT_CPU_ALTAIRROM)
         install_ALTAIRbootROM();
     m68k_clear_memory();


### PR DESCRIPTION
Changing the CPU's memory or CPU configuration currently removes memory mapped by a device:
```
sim> set jadedd ena
sim> show cpu
CPU
        64KB, NOITRAP, 8080, AZ80, STOPONHALT
        NONBANKED, ALTAIRROM, VERBOSE,
       0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF [16k]
00000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
04000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
08000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
0C000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWMMMMWWWWWWWWWWWWMMMMWWWWWWWWWWWR,
0x[02 03 04 05 08 09 0A 10 11 12 13 14 15 16 17 18 19 28 29 2A 2B 32 33 43 A0 A1 A2 A3 A4 A5 A6 A7 FD FE FF]
        MMU, NOSWITCHER, NOPO
sim> set cpu 24k
sim> show cpu
CPU
        24KB, NOITRAP, 8080, AZ80, STOPONHALT
        NONBANKED, ALTAIRROM, VERBOSE,
       0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF [16k]
00000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
04000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU
08000: UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU
0C000: UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUR,
0x[02 03 04 05 08 09 0A 10 11 12 13 14 15 16 17 18 19 28 29 2A 2B 32 33 43 A0 A1 A2 A3 A4 A5 A6 A7 FD FE FF]
        MMU, NOSWITCHER, NOPO
sim>
```
Changing the CPU type or memory configuration should not change a device's configuration. This PR modifies cpu_clear() to no longer cause device memory maps to be removed from `MDEV mmu_table[]` when the following CPU commands are executed:
```
CPU [NO]BANKED
CPU CLEARMEMORY
CPU [CHIP TYPE]
CPU [MEMORY SIZE]
```
```
sim> set jadedd ena
sim> show cpu
CPU
        64KB, NOITRAP, 8080, AZ80, STOPONHALT
        NONBANKED, ALTAIRROM, VERBOSE,
       0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF [16k]
00000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
04000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
08000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
0C000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWMMMMWWWWWWWWWWWWMMMMWWWWWWWWWWWR,
0x[02 03 04 05 08 09 0A 10 11 12 13 14 15 16 17 18 19 28 29 2A 2B 32 33 43 A0 A1 A2 A3 A4 A5 A6 A7 FD FE FF]
        MMU, NOSWITCHER, NOPO
sim> set cpu 24k
sim> show cpu
CPU
        24KB, NOITRAP, 8080, AZ80, STOPONHALT
        NONBANKED, ALTAIRROM, VERBOSE,
       0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF [16k]
00000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
04000: WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU
08000: UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU
0C000: UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUMMMMUUUUUUUUUUUUMMMMUUUUUUUUUUUR,
0x[02 03 04 05 08 09 0A 10 11 12 13 14 15 16 17 18 19 28 29 2A 2B 32 33 43 A0 A1 A2 A3 A4 A5 A6 A7 FD FE FF]
        MMU, NOSWITCHER, NOPO
sim>
```