### PR TITLE
CMake: generate.py 'experimental' rule flexibility

### DIFF
--- a/README-CMake.md
+++ b/README-CMake.md
@@ -1386,9 +1386,19 @@ solution is `cmake/generate.py` to update the affected simulator
 ```sh
 ## You have to be in the cmake subdirectory to run the generate.py script
 $ cd cmake
+$ python -m generate --help
+usage: generate.py [-h] [--debug [DEBUG]] [--srcdir SRCDIR] [--orphans]
+
+SIMH simulator CMakeLists.txt generator.
+
+options:
+  -h, --help       show this help message and exit
+  --debug [DEBUG]  Debug level (0-3, 0 == off)
+  --srcdir SRCDIR  makefile source directory.
+  --orphans        Check for packaging orphans
+
 # [simh_source] is the absolute path to your top-level SIMH source directory
-$ python -m generate
-generate.py: Expecting to emit 77 simulators.
+$ python -m generate --orphans
 generate.py: Looking for makefile, starting in [simh-source]/open-simh/cmake
 generate.py: Looking for makefile, trying [simh-source]/open-simh
 generate.py: Processing [simh-source]/open-simh/makefile
@@ -1423,6 +1433,7 @@ generate.py: all target vaxstation4000m60
 generate.py: all target microvax3100m80
 generate.py: all target vaxstation4000vlc
 generate.py: all target infoserver1000
+generate.py: all target nd100
 generate.py: all target nova
 generate.py: all target eclipse
 generate.py: all target hp2100
@@ -1475,6 +1486,7 @@ generate.py: all target sel32
 generate.py: exp target alpha
 generate.py: exp target pdq3
 generate.py: exp target sage
+generate.py: Expecting to emit 78 simulators.
 ==== writing to [simh-source]/open-simh/3B2/CMakeLists.txt
 ==== writing to [simh-source]/open-simh/ALTAIR/CMakeLists.txt
 ==== writing to [simh-source]/open-simh/AltairZ80/CMakeLists.txt
@@ -1495,6 +1507,7 @@ generate.py: exp target sage
 ==== writing to [simh-source]/open-simh/Intel-Systems/scelbi/CMakeLists.txt
 ==== writing to [simh-source]/open-simh/Interdata/CMakeLists.txt
 ==== writing to [simh-source]/open-simh/LGP/CMakeLists.txt
+==== writing to [simh-source]/open-simh/ND100/CMakeLists.txt
 ==== writing to [simh-source]/open-simh/NOVA/CMakeLists.txt
 ==== writing to [simh-source]/open-simh/PDP1/CMakeLists.txt
 ==== writing to [simh-source]/open-simh/PDP10/CMakeLists.txt

--- a/cmake/generate.py
+++ b/cmake/generate.py
@@ -32,9 +32,9 @@ def process_makefile(makefile_dir, debug=0):
     if debug >= 4:
         pprint.pp(defs)
 
-    all_rule = rules.get('all')
+    all_rule = rules.get('all') or rules.get('ALL')
     if all_rule is None:
-        print('{0}: "all" rule not found. Cannot process.'.format(GEN_SCRIPT_NAME))
+        print('{0}: "all" rule not found. Cannot proceed.'.format(GEN_SCRIPT_NAME))
 
     simulators = SCC.CMakeBuildSystem()
     for all_targ in SPM.shallow_expand_vars(all_rule, defs).split():
@@ -42,9 +42,10 @@ def process_makefile(makefile_dir, debug=0):
         walk_target_deps(all_targ, defs, rules, actions, simulators, debug=debug)
 
     experimental_rule = rules.get('experimental')
-    for experimental_targ in SPM.shallow_expand_vars(experimental_rule, defs).split():
-        print("{0}: exp target {1}".format(GEN_SCRIPT_NAME, experimental_targ))
-        walk_target_deps(experimental_targ, defs, rules, actions, simulators, debug=debug)
+    if experimental_rule is not None:
+        for experimental_targ in SPM.shallow_expand_vars(experimental_rule, defs).split():
+            print("{0}: exp target {1}".format(GEN_SCRIPT_NAME, experimental_targ))
+            walk_target_deps(experimental_targ, defs, rules, actions, simulators, debug=debug)
 
     simulators.collect_vars(defs, debug=debug)
     return simulators
@@ -131,14 +132,13 @@ if __name__ == '__main__':
                       help='Debug level (0-3, 0 == off)')
     args.add_argument('--srcdir', default=None,
                       help='makefile source directory.')
-    ## args.add_argument('--file', '-f', default=os.path.join(GEN_SCRIPT_DIR, 'simh_makefile.cmake'),
-    ##                  help='Output file for "all-in-one" CMakeLists.txt, default is simh_makefile.cmake')
+    args.add_argument('--orphans', action='store_true',
+                      help='Check for packaging orphans')
+
     flags = vars(args.parse_args())
 
     debug_level = flags.get('debug')
     makefile_dir = flags.get('srcdir')
-
-    print('{0}: Expecting to emit {1} simulators.'.format(GEN_SCRIPT_NAME, len(SPKG.package_info.keys())))
 
     found_makefile = True
     if makefile_dir is None:
@@ -174,12 +174,15 @@ if __name__ == '__main__':
         for sim in sims.dirs[simdir].simulators.keys():
             SPKG.package_info[sim].encountered()
 
-    orphans = [ sim for sim, pkg_info in SPKG.package_info.items() if not pkg_info.was_processed() ]
-    if len(orphans) > 0:
-        print('{0}: Simulators not extracted from makefile:'.format(GEN_SCRIPT_NAME))
-        for orphan in orphans: 
-            print('{0}{1}'.format(' ' * 4, orphan))
-        sys.exit(1)
+    if flags.get('orphans'):
+        print('{0}: Expecting to emit {1} simulators.'.format(GEN_SCRIPT_NAME, len(SPKG.package_info.keys())))
+
+        orphans = [ sim for sim, pkg_info in SPKG.package_info.items() if not pkg_info.was_processed() ]
+        if len(orphans) > 0:
+            print('{0}: Simulators not extracted from makefile:'.format(GEN_SCRIPT_NAME))
+            for orphan in orphans: 
+                print('{0}{1}'.format(' ' * 4, orphan))
+            sys.exit(1)
 
     if debug_level >= 1:
         pp = pprint.PrettyPrinter()

--- a/cmake/simgen/packaging.py
+++ b/cmake/simgen/packaging.py
@@ -30,16 +30,18 @@ class PkgFamily:
             pkg_description += '.'
         sims = []
         for sim, pkg in package_info.items():
-            if pkg.family is self:
+            if pkg.family is self and pkg.was_processed():
                 sims.append(sim)
-        sims.sort()
-        pkg_description += " Simulators: " + ', '.join(sims)
-        indent0 = ' ' * indent
-        indent4 = ' ' * (indent + 4)
-        stream.write(indent0 + "cpack_add_component(" + self.component_name + "\n")
-        stream.write(indent4 + "DISPLAY_NAME \"" + self.display_name + "\"\n")
-        stream.write(indent4 + "DESCRIPTION \"" + pkg_description + "\"\n")
-        stream.write(indent0 + ")\n")
+
+        if len(sims) > 0:
+            sims.sort()
+            pkg_description += " Simulators: " + ', '.join(sims)
+            indent0 = ' ' * indent
+            indent4 = ' ' * (indent + 4)
+            stream.write(indent0 + "cpack_add_component(" + self.component_name + "\n")
+            stream.write(indent4 + "DISPLAY_NAME \"" + self.display_name + "\"\n")
+            stream.write(indent4 + "DESCRIPTION \"" + pkg_description + "\"\n")
+            stream.write(indent0 + ")\n")
 
     def __lt__(self, obj):
         return self.component_name < obj.component_name


### PR DESCRIPTION
Requested change: Successfully process makefiles without the 'experimental' rule and fewer simulators than the full open-simh packaging.
