### PR TITLE
SIGMA: Bugfixes in various device modules

### DIFF
--- a/sigma/sigma_bugs.txt
+++ b/sigma/sigma_bugs.txt
@@ -131,6 +131,19 @@
 124. IO, all devices: moved SIO reject-on-interrupt test to devices.
 125. DP: SIO will knock down pending device interrupts and allow operation to proceed.
 126. MT: AIO must mask unit number before calling TDV status.
+127. IO: location 20/21 set incorrectly in the even, non-zero register case.
+128. CPU: WAIT must be implemented for correct operation of CP-V.
+129. DP: On 10 byte models, SENSE length errors can't happen. On 16 byte models,
+     SENSE length errors only occur if length == 0 || length > 16.
+130. IO: DVT_NOTDEV macro incorrect.
+131. DP: Test for non-existent device returns wrong status.
+132. DK: Test for non-existent device returns wrong status.
+133. MT: Test for non-existent device returns wrong status.
+134. RAD: Test for non-existent device returns wrong status.
+135. DP: TIO status should return non-operational for unattached device.
+136. DK: TIO status should return non-operational for unattached device.
+137. NT: TIO status should return non-operational for unattached device.
+138. IO: Device mapping algorithm creates false dispatch points.
 
 Diagnostic Notes
 ----------------

--- a/sigma/sigma_dk.c
+++ b/sigma/sigma_dk.c
@@ -1,6 +1,6 @@
 /* sigma_dk.c: 7250/7251-7252 cartridge disk simulator
 
-   Copyright (c) 2007-2022, Robert M Supnik
+   Copyright (c) 2007-2024, Robert M Supnik
 
    Permission is hereby granted, free of charge, to any person obtaining a
    copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,9 @@
 
    dk           7250/7251-7252 cartridge disk
 
+   11-Feb-24    RMS     Report non-operational if not attached (Ken Rector)
+   01-Feb-24    RMS     Fixed nx unit test (Ken Rector)
+   15-Dec-22    RMS     Moved SIO interrupt test to devices
    02-Jul-22    RMS     Fixed bugs in multi-unit operation
 
    Transfers are always done a sector at a time.
@@ -129,9 +132,9 @@ REG dk_reg[] = {
     };
 
 MTAB dk_mod[] = {
-    { MTAB_XTD|MTAB_VUN, 0, "write enabled", "WRITEENABLED", 
+    { MTAB_XTD|MTAB_VUN, 0, "write enabled", "WRITEENABLED",
         &set_writelock, &show_writelock,   NULL, "Write enable drive" },
-    { MTAB_XTD|MTAB_VUN, 1, NULL, "LOCKED", 
+    { MTAB_XTD|MTAB_VUN, 1, NULL, "LOCKED",
         &set_writelock, NULL,   NULL, "Write lock drive" },
     { MTAB_XTD|MTAB_VDV, 0, "CHAN", "CHAN",
       &io_set_dvc, &io_show_dvc, NULL },
@@ -164,8 +167,10 @@ int32 iu;
 UNIT *uptr;
 
 if ((un >= DK_NUMDR) ||                                 /* inv unit num? */
-    (dk_unit[un].flags & UNIT_DIS))                     /* disabled unit? */
-    return DVT_NODEV;
+    (dk_unit[un].flags & UNIT_DIS)) {                   /* disabled unit? */
+    *dvst = DVT_NODEV;
+    return 0;
+    }
 switch (op) {                                           /* case on op */
 
     case OP_SIO:                                        /* start I/O */
@@ -412,12 +417,17 @@ return FALSE;                                           /* cmd done */
 
 uint32 dk_tio_status (uint32 un)
 {
-uint32 i;
+uint32 i, st;
 
+st = DVS_AUTO;                                          /* flags */
+if (sim_is_active (&dk_unit[un]))                       /* active => busy */
+    st |= DVS_DBUSY;
+else if ((dk_unit[un].flags & UNIT_ATT) == 0)           /* not att => offl */
+    st |= DVS_DOFFL;                                 
 for (i = 0; i < DK_NUMDR; i++) {                        /* loop thru units */
     if (sim_is_active (&dk_unit[i]))                    /* active? */
-        return (DVS_AUTO | DVS_CBUSY | (CC2 << DVT_V_CC) |
-            ((i == un)? DVS_DBUSY: 0));
+        st |= (DVS_CBUSY | (CC2 << DVT_V_CC));          /* ctrl is busy */
+        return st;
     }
 return DVS_AUTO;
 }

--- a/sigma/sigma_io_defs.h
+++ b/sigma/sigma_io_defs.h
@@ -149,7 +149,7 @@ typedef struct {
 #define DVT_GETCC(x)    (((x) >> DVT_V_CC) & DVT_M_CC)
 #define DVT_GETDVS(x)   (((x) >> DVT_V_DVS) & DVT_M_DVS)
 #define DVT_NOST        (CC1 << DVT_V_CC)               /* no status */
-#define DVT_NODEV       ((CC1|CC2) < DVT_V_CC)          /* no device */
+#define DVT_NODEV       ((CC1|CC2) << DVT_V_CC)          /* no device */
 
 /* Read and write direct address format */
 


### PR DESCRIPTION
Fix three kinds of error in device modules.  Discovered while getting standalone System Exerciser to run.

IO: DVT_NOTDEV macro incorrect, Device mapping algorithm creates false dispatch points. This mapped Multi Unit Controller and Single Unit Controller to same device. 
DP, DP, MT, RAD:  Test for non-existent device returns wrong status. 
DP, DK, MT: TIO status should return non-operational for unattached device.