### PR TITLE
AltairZ80: Enable SIO interrupt service event after BOOT

### DIFF
--- a/AltairZ80/altairz80_sio.c
+++ b/AltairZ80/altairz80_sio.c
@@ -581,6 +581,8 @@ static t_stat sio_reset(DEVICE *dptr) {
             if (TerminalLines[i].conn)
                 tmxr_reset_ln(&TerminalLines[i]);
     mapAltairPorts();
+    if (sio_unit.flags & UNIT_SIO_INTERRUPT)
+        sim_activate(&sio_unit, sio_unit.wait);             /* activate unit    */
     return SCPE_OK;
 }
 


### PR DESCRIPTION
The `boot` command causes all devices to reset which removes the `SET SIO INTERRUPT` service routine from the SIMH event queue which disables interrupt processing. The user must escape back to the `simh>` prompt and `SET SIO INTERRUPT` again after boot. An example of the problem:

```
at dsk altdos.dsk
set sio interrupt
boot dsk

MEMORY SIZE? << Enter >>
INTERRUPTS? Y << Enter >>
HIGHEST DISK NUMBER? << interrupt never happens, program hangs >>
```

This PR has sio_reset put the SIO interrupt service routine back on the event queue if interrupts have been enabled with `SET SIO INTERRUPT`.

```
at dsk altdos.dsk
set sio interrupt
boot dsk

MEMORY SIZE? 
INTERRUPTS? Y
HIGHEST DISK NUMBER? 1
HOW MANY DISK FILES? 1
HOW MANY RANDOM FILES? 1

056943 BYTES AVAILABLE
DOS MONITOR VER 1.0
COPYRIGHT 1977 BY MITS INC
.
```