### PR TITLE
SCP: sprint_val comma bug, GH: Remnant symlinks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,26 @@ jobs:
           - scelbi 3b2 i701 i704 i7010 i7070 i7080 i7090 sigma uc15 i650 sel32 intel-mds ibm1130
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
+      ## Workaround for remnant symlinks in /usr/local pointing back to
+      ## macOS frameworks.
+      ##
+      ## Future: Will have to keep an eye on SDL_ttf's Python dependency
+      ## so that the correct/appropriate Python version is removed.
+      - name: Remnant symlink cleanup (macOS)
+        if: ${{runner.os == 'macOS'}}
+        run: |
+          brew unlink python@3 || true
+          brew uninstall --ignore-dependencies python@3 || true
+          brew unlink python@3.12 || true
+          brew uninstall --ignore-dependencies python@3.12 || true
+          for f in $(find /usr/local/bin -type l -print); do \
+            (readlink $f | grep -q -s "/Library") && echo Removing "$f" && rm -f "$f"; \
+          done || exit 0
+      ## Install our regular dependencies.
+      - name: Install dependencies (macOS)
         if: ${{runner.os == 'macOS'}}
         run: sh -ex .travis/deps.sh osx
-      - name: Install dependencies
+      - name: Install dependencies (Linux)
         if: ${{runner.os == 'Linux'}}
         run: sh -ex .travis/deps.sh linux
       - name: makefile build

--- a/.github/workflows/cmake-builds.yml
+++ b/.github/workflows/cmake-builds.yml
@@ -46,15 +46,22 @@ jobs:
         os: [macos-12, macos-11]
     steps:
     - uses: actions/checkout@v3
-    ## For some reason, the macos-11 image has symlinks to /Library in /usr/local/bin
-    - name: Clean /usr/local/bin symlinks
+    ## Workaround for remnant symlinks in /usr/local pointing back to
+    ## macOS frameworks.
+    ##
+    ## Future: Will have to keep an eye on SDL_ttf's Python dependency
+    ## so that the correct/appropriate Python version is removed.
+    - name: Remnant symlink cleanup
       run: |
+        brew unlink python@3 || true
+        brew uninstall --ignore-dependencies python@3 || true
+        brew unlink python@3.12 || true
+        brew uninstall --ignore-dependencies python@3.12 || true
         for f in $(find /usr/local/bin -type l -print); do \
-           (readlink $f | grep -q -s "/Library") && echo Removing "$f" && rm -f "$f"; \
-         done || exit 0
+          (readlink $f | grep -q -s "/Library") && echo Removing "$f" && rm -f "$f"; \
+        done || exit 0
     - name: Install dependencies
-      run: |
-        sh -ex .travis/deps.sh osx
+      run: sh -ex .travis/deps.sh osx
     - name: cmake-builder.sh
       run: |
         cmake/cmake-builder.sh --config Release --flavor xcode --lto --notest --cpack_suffix x86_64.${{matrix.os}}

--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -2,11 +2,8 @@
 
 install_osx() {
     brew update
-    brew install pkg-config
-    brew install pcre libpng libedit
-    brew install sdl2 freetype2 sdl2_ttf
-    brew install vde
-    brew install cmake gnu-getopt coreutils
+    brew install pkg-config pcre libpng libedit sdl2 freetype2 sdl2_ttf \
+        vde cmake gnu-getopt coreutils
 }
 
 install_linux() {

--- a/scp.c
+++ b/scp.c
@@ -260,7 +260,7 @@
 #define MIN(a,b)  (((a) <= (b)) ? (a) : (b))
 #endif
 /* Max width of a value expressed as a formatted string */
-#define MAX_WIDTH ((int) ((CHAR_BIT * sizeof (t_value) * 4 + 3)/3))
+#define MAX_WIDTH ((CHAR_BIT * sizeof (t_value) * 4 + 3) / 3)
 
 
 /* search logical and boolean ops */
@@ -7406,8 +7406,11 @@ t_stat dir_cmd (int32 flg, CONST char *cptr)
 {
 DIR_CTX dir_state;
 t_stat r;
-char WildName[PATH_MAX + 1];
+char *WildName;
 struct stat filestat;
+
+if ((WildName = (char *) calloc(PATH_MAX + 1, sizeof(char))) == NULL)
+  return SCPE_MEM;
 
 GET_SWITCHES (cptr);                                    /* get switches */
 memset (&dir_state, 0, sizeof (dir_state));
@@ -7431,8 +7434,9 @@ if (r != SCPE_OK) {
     sim_printf ("\n Directory of %s\n\n", cp);
     sim_printf ("File Not Found\n\n");
     free (cp);
-    return SCPE_OK;
+    r = SCPE_OK;
     }
+free(WildName);
 return r;
 }
 
@@ -11688,7 +11692,7 @@ dbuf[MAX_WIDTH] = 0;
 d = MAX_WIDTH;
 do {
     d = d - 1;
-    digit = (int32) (val % radix);
+    digit = val % radix;
     val = val / radix;
     dbuf[d] = (char)((digit <= 9)? '0' + digit: 'A' + (digit - 10));
     } while ((d > 0) && (val != 0));
@@ -11706,7 +11710,7 @@ switch (format) {
                 break;
         ndigits = MAX_WIDTH - digit;
         commas = (ndigits - 1)/3;
-        for (digit=0; digit<ndigits-3; digit++)
+        for (digit=0; digit + 3 < ndigits; digit++)
             dbuf[MAX_WIDTH + (digit - ndigits) - (ndigits - digit - 1)/3] = dbuf[MAX_WIDTH + (digit - ndigits)];
         for (digit=1; digit<=commas; digit++)
             dbuf[MAX_WIDTH - (digit * 4)] = ',';


### PR DESCRIPTION
- Fix comma separator code segmentation fault: "ndigit - 3" can become a very large unsigned number for ndigit < 3.

- dir_cmd: Allocate WildName from heap to reduce stack pressure.

- Github CI/CD: Remnant symlink issue reappeared, afflicting the makefile-based build. For better or worse, the workaround is now dependent on specific Python versions that must be removed, unlinked and any remnant symlinks that HomeBrew decided it needed to install in /usr/local/bin. The Python upgrade is triggered by the sdl2_ttf package.

  According to the Github image maintainers, this is an old, known issue in macOS images that originates inside of Homebrew.