### PR TITLE
IBM 1130: GUI resource file, RegSanityCheck fix

### DIFF
--- a/Ibm1130/ibm1130_cpu.c
+++ b/Ibm1130/ibm1130_cpu.c
@@ -246,8 +246,6 @@ extern UNIT cr_unit, prt_unit[];
 #  define ARFSET(v)                         /* without GUI, no need for setting ARF */
 #endif
 
-static void   init_console_window (void);
-static void   destroy_console_window (void);
 static t_stat view_cmd (int32 flag, CONST char *cptr);
 static t_stat cpu_attach (UNIT *uptr, CONST char *cptr);
 static t_bool bsctest (int32 DSPLC, t_bool reset_V);

--- a/Ibm1130/ibm1130_cr.c
+++ b/Ibm1130/ibm1130_cr.c
@@ -728,7 +728,7 @@ extern int cgi;
 static int16 ascii_to_card[256];
 
 static CPCODE *cardcode;
-static int ncardcode;
+static size_t ncardcode;
 static FILE *deckfile = NULL;
 static char tempfile[128];
 static int any_punched = 0;
@@ -760,7 +760,7 @@ t_bool program_is_loaded = FALSE;
 
 /* lookup_codetable - use code flag setting to get code table pointer and length */
 
-static t_bool lookup_codetable (int32 match, CPCODE **pcode, int *pncode)
+static t_bool lookup_codetable (int32 match, CPCODE **pcode, size_t *pncode)
 {
     switch (match) {
         case CODE_029:
@@ -793,7 +793,7 @@ static t_bool lookup_codetable (int32 match, CPCODE **pcode, int *pncode)
 t_stat set_active_cr_code (int match)
 {
     CPCODE *code;
-    int i, ncode;
+    size_t ncode;
 
     SET_ACTCODE(cr_unit, match);
 
@@ -801,6 +801,8 @@ t_stat set_active_cr_code (int match)
         return SCPE_ARG;
 
     if (code != NULL) {                 /* if an ASCII mode was selected */
+        size_t i;
+
         memset(ascii_to_card, 0, sizeof(ascii_to_card));
 
         for (i = 0; i < ncode; i++)     /* set ascii to card code table */
@@ -881,7 +883,7 @@ static int32 guess_cr_code (void)
 static t_stat cp_set_code (UNIT *uptr, int32 match, CONST char *cptr, void *desc)
 {
     CPCODE *code;
-    int ncode;
+    size_t ncode;
 
     if (! lookup_codetable(match, &code, &ncode))
         return SCPE_ARG;
@@ -1020,7 +1022,7 @@ t_stat cr_boot (int32 unitno, DEVICE *dptr)
 
 char card_to_ascii (uint16 hol)
 {
-    int i;
+    size_t i;
 
     for (i = 0; i < ncardcode; i++)
         if (cardcode[i].hollerith == hol)
@@ -1033,7 +1035,7 @@ char card_to_ascii (uint16 hol)
 
 char hollerith_to_ascii (uint16 hol)
 {
-    int i;
+    size_t i;
 
     for (i = 0; i < ncardcode; i++)
         if (cardcode_029[i].hollerith == hol)
@@ -1222,6 +1224,9 @@ static char * skipbl (char *str)
     return str;
 }
 
+#if THIS_IS_EVER_NEEDED
+/* This function is never called. Leaving it in if the IBM-1130 author
+ * deems it significant. */
 static char * trim (char *str)
 {
     char *s, *lastnb;
@@ -1234,6 +1239,7 @@ static char * trim (char *str)
 
     return str;
 }
+#endif
 
 /* alltrim - remove all leading and trailing whitespace from a string */
 
@@ -2382,7 +2388,7 @@ static DWORD CALLBACK pcr_thread (LPVOID arg)
                 if (! GetOverlappedResult(hpcr, &ovRd, &nrcvd, TRUE))
                     report_error("PCR_Read", GetLastError());
                 else if (cr_unit.flags & UNIT_DEBUG)
-                    printf("PCR_Read: event, %d rcvd\n", nrcvd);
+                    printf("PCR_Read: event, %ld rcvd\n", nrcvd);
                 break;
 
             case WAIT_OBJECT_0+1:                       /* write complete */
@@ -2391,7 +2397,7 @@ static DWORD CALLBACK pcr_thread (LPVOID arg)
                 if (! GetOverlappedResult(hpcr, &ovWr, &nwritten, TRUE))
                     report_error("PCR_Write", GetLastError());
                 else if (cr_unit.flags & UNIT_DEBUG)
-                    printf("PCR_Write: event, %d sent\n", nwritten);
+                    printf("PCR_Write: event, %ld sent\n", nwritten);
                 continue;
 
             case WAIT_OBJECT_0+2:                       /* reset request from simulator */

--- a/Ibm1130/ibm1130_gui.c
+++ b/Ibm1130/ibm1130_gui.c
@@ -110,8 +110,6 @@ extern t_bool program_is_loaded;
     void disk_ready (int ready)               {}
     void disk_unlocked (int unlocked)         {}
     void gui_run (int running)                {} 
-    static void init_console_window (void)    {}
-    static void destroy_console_window (void) {}
 
     t_stat console_reset (DEVICE *dptr)                         {return SCPE_OK;}
     long   stuff_cmd (char *cmd)                                {return 0;}


### PR DESCRIPTION
- Add the missing ibm1130.rc GUI resource file to the Windows build so that the GUI renders correctly.

- Add "TEST_ARGS" argument to CMake's add_simulator function so that the IBM 1130 simulator can pass to "-g" on the command line to disable the GUI when running RegisterSanityCheck, i.e.:

    ibm1130 RegisterSanityCheck -g

  This fixes an edge case Heisenbug encountered during Github CI/CD tests where ibm1130 appears to hang indefinitely on the Windows runners.

  The cause is the GUI's Pump() thread function being prematurely terminated before all GUI resources are acquired: `RegisterSanityCheck` completes and starts terminating the simulator, which prejudiciously terminates the Pump() thread. The Pump() thread, in the meantime, can be terminated in the middle of resource acquisition due to thread scheduling latency. The net result is an infinite loop in the MS C runtime trying to exit the process with unstable internal state. (Separate patch: synchronization across main and Pump() threads to ensure resource acquisition completes.)

  This issue never shows up (cannot show up) on non-Windows platforms or the SIMH makefile.

- cmake/generator.py, cmake/simgen: Add a "test_args" keyword argument to the BasicSimulator constructor that holds the tests argument parameter emitted as the "TEST_ARGS" argument to a simulator's add_simulator(). Ensure that the IBM 1130 emits 'TEST_ARG "-g"' in its add_simulator().

- scp.c: reset_all_p() adds 'P' to the existing switches, versus saving sim_switches and ONLY setting the 'P' power-up reset switch. Net effect is that the IBM 1130 simulator actually sees the 'G' flag that inhibits the GUI during the console device reset.

- Ibm1130/ibm1130_cr.c

  - Fix printf() warnings (format should be long, not int)
  - Signed/unsigned mismatch, size_t for array indexing
  - Comment out the unused trim() function.

- Ibm1130/ibm1130_cpu.c, ibm1130_gui.c: Remove undefined static functions.