### PR TITLE
VAX: Add UW device to 8600 and 8200.

### DIFF
--- a/VAX/CMakeLists.txt
+++ b/VAX/CMakeLists.txt
@@ -566,6 +566,7 @@ add_simulator(vax8200
         vax_sys.c
         vax_syscm.c
         vax_watch.c
+        vax_uw.c
         vax820_stddev.c
         vax820_bi.c
         vax820_mem.c
@@ -614,6 +615,7 @@ add_simulator(vax8600
         vax_mmu.c
         vax_sys.c
         vax_syscm.c
+        vax_uw.c
         vax860_stddev.c
         vax860_sbia.c
         vax860_abus.c

--- a/VAX/vax820_defs.h
+++ b/VAX/vax820_defs.h
@@ -331,6 +331,7 @@ typedef struct {
 #define INT_V_DUPTX     12
 #define INT_V_RK        13
 #define INT_V_CH        14
+#define INT_V_UW        15
 
 #define INT_V_LPT       0                               /* BR4 */
 #define INT_V_PTR       1
@@ -365,6 +366,7 @@ typedef struct {
 #define INT_TDRX        (1u << INT_V_TDRX)
 #define INT_TDTX        (1u << INT_V_TDTX)
 #define INT_CH          (1u << INT_V_CH)
+#define INT_UW          (1u << INT_V_UW)
 
 #define IPL_DTA         (0x16 - IPL_HMIN)
 #define IPL_CR          (0x16 - IPL_HMIN)
@@ -390,6 +392,7 @@ typedef struct {
 #define IPL_RK          (0x15 - IPL_HMIN)
 #define IPL_TDRX        (0x14 - IPL_HMIN)
 #define IPL_TDTX        (0x14 - IPL_HMIN)
+#define IPL_UW          (0x15 - IPL_HMIN)
 
 /* Device vectors */
 

--- a/VAX/vax820_syslist.c
+++ b/VAX/vax820_syslist.c
@@ -62,6 +62,7 @@ extern DEVICE xu_dev, xub_dev;
 extern DEVICE dmc_dev;
 extern DEVICE dup_dev;
 extern DEVICE ch_dev;
+extern DEVICE uw_dev;
 
 extern UNIT cpu_unit;
 extern void WriteB (uint32 pa, int32 val);
@@ -103,6 +104,7 @@ DEVICE *sim_devices[] = {
     &dmc_dev,
     &dup_dev,
     &ch_dev,
+    &uw_dev,
     NULL
     };
 

--- a/VAX/vax860_defs.h
+++ b/VAX/vax860_defs.h
@@ -368,6 +368,7 @@ typedef struct {
 #define INT_V_DUPTX     12
 #define INT_V_RK        13
 #define INT_V_CH        14
+#define INT_V_UW        15
 
 #define INT_V_LPT       0                               /* BR4 */
 #define INT_V_PTR       1
@@ -402,6 +403,7 @@ typedef struct {
 #define INT_TDRX        (1u << INT_V_TDRX)
 #define INT_TDTX        (1u << INT_V_TDTX)
 #define INT_CH          (1u << INT_V_CH)
+#define INT_UW          (1u << INT_V_UW)
 
 #define IPL_DTA         (0x16 - IPL_HMIN)
 #define IPL_CR          (0x16 - IPL_HMIN)
@@ -427,6 +429,7 @@ typedef struct {
 #define IPL_RK          (0x15 - IPL_HMIN)
 #define IPL_TDRX        (0x14 - IPL_HMIN)
 #define IPL_TDTX        (0x14 - IPL_HMIN)
+#define IPL_UW          (0x15 - IPL_HMIN)
 
 /* Device vectors */
 

--- a/VAX/vax860_syslist.c
+++ b/VAX/vax860_syslist.c
@@ -65,6 +65,7 @@ extern DEVICE xu_dev, xub_dev;
 extern DEVICE dmc_dev;
 extern DEVICE dup_dev;
 extern DEVICE ch_dev;
+extern DEVICE uw_dev;
 
 DEVICE *sim_devices[] = { 
     &cpu_dev,
@@ -102,6 +103,7 @@ DEVICE *sim_devices[] = {
     &dmc_dev,
     &dup_dev,
     &ch_dev,
+    &uw_dev,
     NULL
     };
 

--- a/Visual Studio Projects/VAX8200.vcproj
+++ b/Visual Studio Projects/VAX8200.vcproj
@@ -396,6 +396,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\VAX\vax_uw.c"
+				>
+			</File>
+			<File
 				RelativePath="..\VAX\vax_watch.c"
 				>
 			</File>

--- a/Visual Studio Projects/VAX8200.vcxproj
+++ b/Visual Studio Projects/VAX8200.vcxproj
@@ -320,6 +320,7 @@
     <ClCompile Include="..\VAX\vax_octa.c" />
     <ClCompile Include="..\VAX\vax_sys.c" />
     <ClCompile Include="..\VAX\vax_syscm.c" />
+    <ClCompile Include="..\VAX\vax_uw.c" />
     <ClCompile Include="..\VAX\vax_watch.c" />
   </ItemGroup>
   <ItemGroup>

--- a/Visual Studio Projects/VAX8600.vcproj
+++ b/Visual Studio Projects/VAX8600.vcproj
@@ -407,6 +407,10 @@
 				RelativePath="..\VAX\vax_syscm.c"
 				>
 			</File>
+			<File
+				RelativePath="..\VAX\vax_uw.c"
+				>
+			</File>
 			<Filter
 				Name="slirp"
 				>

--- a/Visual Studio Projects/VAX8600.vcxproj
+++ b/Visual Studio Projects/VAX8600.vcxproj
@@ -323,6 +323,7 @@
     <ClCompile Include="..\VAX\vax_octa.c" />
     <ClCompile Include="..\VAX\vax_sys.c" />
     <ClCompile Include="..\VAX\vax_syscm.c" />
+    <ClCompile Include="..\VAX\vax_uw.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\PDP11\pdp11_ddcmp.h" />

--- a/makefile
+++ b/makefile
@@ -1671,7 +1671,7 @@ VAX8200 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
 	${VAXD}/vax_mmu.c ${VAXD}/vax_sys.c  ${VAXD}/vax_syscm.c \
 	${VAXD}/vax_watch.c ${VAXD}/vax820_stddev.c ${VAXD}/vax820_bi.c \
 	${VAXD}/vax820_mem.c ${VAXD}/vax820_uba.c ${VAXD}/vax820_ka.c \
-	${VAXD}/vax820_syslist.c \
+	${VAXD}/vax_uw.c ${VAXD}/vax820_syslist.c \
 	${PDP11D}/pdp11_rl.c ${PDP11D}/pdp11_rq.c ${PDP11D}/pdp11_ts.c \
 	${PDP11D}/pdp11_dz.c ${PDP11D}/pdp11_lp.c ${PDP11D}/pdp11_tq.c \
 	${PDP11D}/pdp11_xu.c ${PDP11D}/pdp11_ry.c ${PDP11D}/pdp11_cr.c \
@@ -1686,7 +1686,7 @@ VAX8600 = ${VAXD}/vax_cpu.c ${VAXD}/vax_cpu1.c ${VAXD}/vax_fpa.c \
 	${VAXD}/vax_mmu.c ${VAXD}/vax_sys.c  ${VAXD}/vax_syscm.c \
 	${VAXD}/vax860_stddev.c ${VAXD}/vax860_sbia.c \
 	${VAXD}/vax860_abus.c ${VAXD}/vax780_uba.c ${VAXD}/vax7x0_mba.c \
-	${VAXD}/vax860_syslist.c \
+	${VAXD}/vax_uw.c ${VAXD}/vax860_syslist.c \
 	${PDP11D}/pdp11_rl.c ${PDP11D}/pdp11_rq.c ${PDP11D}/pdp11_ts.c \
 	${PDP11D}/pdp11_dz.c ${PDP11D}/pdp11_lp.c ${PDP11D}/pdp11_tq.c \
 	${PDP11D}/pdp11_xu.c ${PDP11D}/pdp11_ry.c ${PDP11D}/pdp11_cr.c \


### PR DESCRIPTION
The VAXstation 100 "unibus window" interface board should work with any Unibus VAX.

The updates are quite trivial... or did I miss anything?  VAX person, please review.