### PR TITLE
VIDEO: open latency, spurious unrecognized events

### DIFF
--- a/VAX/vax4xx_va.c
+++ b/VAX/vax4xx_va.c
@@ -1285,7 +1285,7 @@ if (dptr->flags & DEV_DIS) {
         return SCPE_OK;
     }
 
-if (!vid_active)  {
+if (!vid_is_active())  {
     r = vid_open (dptr, NULL, VA_XSIZE, VA_YSIZE, va_input_captured ? SIM_VID_INPUTCAPTURED : 0);/* display size & capture mode */
     if (r != SCPE_OK)
         return r;
@@ -1382,7 +1382,7 @@ return cpu_set_model (NULL, 0, (val ? "VAXSTATIONGPX" : "MICROVAX"), NULL);
 
 t_stat va_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-if (vid_active)
+if (vid_is_active())
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
 va_input_captured = val;
 return SCPE_OK;

--- a/VAX/vax4xx_vc.c
+++ b/VAX/vax4xx_vc.c
@@ -497,7 +497,7 @@ if (dptr->flags & DEV_DIS) {
         return SCPE_OK;
     }
 
-if (!vid_active && !vc_active)  {
+if (!vid_is_active() && !vc_active)  {
     r = vid_open (dptr, NULL, VC_XSIZE, VC_YSIZE, vc_input_captured ? SIM_VID_INPUTCAPTURED : 0); /* display size */
     if (r != SCPE_OK)
         return r;
@@ -542,7 +542,7 @@ return cpu_set_model (NULL, 0, (val ? "VAXSTATION" : "MICROVAX"), NULL);
 
 t_stat vc_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-if (vid_active)
+if (vid_is_active())
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
 vc_input_captured = val;
 return SCPE_OK;

--- a/VAX/vax4xx_ve.c
+++ b/VAX/vax4xx_ve.c
@@ -1448,7 +1448,7 @@ if (dptr->flags & DEV_DIS) {
         return SCPE_OK;
     }
 
-if (!vid_active && !ve_active)  {
+if (!vid_is_active() && !ve_active)  {
     r = vid_open (dptr, NULL, VE_XSIZE, VE_YSIZE, ve_input_captured ? SIM_VID_INPUTCAPTURED : 0);/* display size & capture mode */
     if (r != SCPE_OK)
         return r;
@@ -1491,7 +1491,7 @@ return cpu_set_model (NULL, 0, (val ? "VAXSTATIONSPX" : "MICROVAX"), NULL);
 
 t_stat ve_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-if (vid_active)
+if (vid_is_active())
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
 ve_input_captured = val;
 return SCPE_OK;

--- a/VAX/vax_va.c
+++ b/VAX/vax_va.c
@@ -1107,7 +1107,7 @@ if (dptr->flags & DEV_DIS) {
         return SCPE_OK;
     }
 
-if (!vid_active)  {
+if (!vid_is_active())  {
     r = vid_open (dptr, NULL, VA_XSIZE, VA_YSIZE, va_input_captured ? SIM_VID_INPUTCAPTURED : 0);/* display size & capture mode */
     if (r != SCPE_OK)
         return r;
@@ -1196,7 +1196,7 @@ return cpu_set_model (NULL, 0, (val ? "VAXSTATIONGPX" : "MICROVAX"), NULL);
 
 t_stat va_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-if (vid_active)
+if (vid_is_active())
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
 va_input_captured = val;
 return SCPE_OK;

--- a/VAX/vax_vc.c
+++ b/VAX/vax_vc.c
@@ -1023,7 +1023,7 @@ if (dptr->flags & DEV_DIS) {
         return SCPE_OK;
     }
 
-if (!vid_active)  {
+if (!vid_is_active())  {
     r = vid_open (dptr, NULL, VC_XSIZE, VC_YSIZE, vc_input_captured ? SIM_VID_INPUTCAPTURED : 0);/* display size & capture mode */
     if (r != SCPE_OK)
         return r;
@@ -1077,7 +1077,7 @@ return cpu_set_model (NULL, 0, (val ? "VAXSTATION" : "MICROVAX"), NULL);
 
 t_stat vc_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-if (vid_active)
+if (vid_is_active())
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
 vc_input_captured = val;
 return SCPE_OK;

--- a/sim_video.c
+++ b/sim_video.c
@@ -33,7 +33,11 @@
 #include "sim_video.h"
 #include "scp.h"
 
-int vid_active = 0;
+#if !defined(UNUSED_ARG)
+/* Squelch compiler warnings about unused formal arguments. */
+#define UNUSED_ARG(arg) (void)(arg)
+#endif
+
 int32 vid_cursor_x;
 int32 vid_cursor_y;
 t_bool vid_mouse_b1 = FALSE;
@@ -87,6 +91,7 @@ t_stat vid_register_gamepad_button_callback (VID_GAMEPAD_CALLBACK callback)
 
 t_stat vid_show (FILE* st, DEVICE *dptr,  UNIT* uptr, int32 val, CONST char* desc)
 {
+UNUSED_ARG(dptr);
 return vid_show_video (st, uptr, val, desc);
 }
 
@@ -104,20 +109,20 @@ char vid_release_key[64] = "Ctrl-Right-Shift";
 #include <SDL.h>
 #include <SDL_thread.h>
 
-static const char *key_names[] = 
-    {"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12", 
-     "0",   "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",    
-     "A",   "B",  "C",  "D",  "E",  "F",  "G",  "H",  "I",  "J", 
-     "K",   "L",  "M",  "N",  "O",  "P",  "Q",  "R",  "S",  "T", 
-     "U",   "V",  "W",  "X",  "Y",  "Z", 
-     "BACKQUOTE",   "MINUS",   "EQUALS", "LEFT_BRACKET", "RIGHT_BRACKET", 
-     "SEMICOLON", "SINGLE_QUOTE", "BACKSLASH", "LEFT_BACKSLASH", "COMMA", 
-     "PERIOD", "SLASH", "PRINT", "SCRL_LOCK", "PAUSE", "ESC", "BACKSPACE", 
-     "TAB", "ENTER", "SPACE", "INSERT", "DELETE", "HOME", "END", "PAGE_UP", 
-     "PAGE_DOWN", "UP", "DOWN", "LEFT", "RIGHT", "CAPS_LOCK", "NUM_LOCK", 
-     "ALT_L", "ALT_R", "CTRL_L", "CTRL_R", "SHIFT_L", "SHIFT_R", 
-     "WIN_L", "WIN_R", "MENU", "KP_ADD", "KP_SUBTRACT", "KP_END", "KP_DOWN", 
-     "KP_PAGE_DOWN", "KP_LEFT", "KP_RIGHT", "KP_HOME", "KP_UP", "KP_PAGE_UP", 
+static const char *key_names[] =
+    {"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+     "0",   "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",
+     "A",   "B",  "C",  "D",  "E",  "F",  "G",  "H",  "I",  "J",
+     "K",   "L",  "M",  "N",  "O",  "P",  "Q",  "R",  "S",  "T",
+     "U",   "V",  "W",  "X",  "Y",  "Z",
+     "BACKQUOTE",   "MINUS",   "EQUALS", "LEFT_BRACKET", "RIGHT_BRACKET",
+     "SEMICOLON", "SINGLE_QUOTE", "BACKSLASH", "LEFT_BACKSLASH", "COMMA",
+     "PERIOD", "SLASH", "PRINT", "SCRL_LOCK", "PAUSE", "ESC", "BACKSPACE",
+     "TAB", "ENTER", "SPACE", "INSERT", "DELETE", "HOME", "END", "PAGE_UP",
+     "PAGE_DOWN", "UP", "DOWN", "LEFT", "RIGHT", "CAPS_LOCK", "NUM_LOCK",
+     "ALT_L", "ALT_R", "CTRL_L", "CTRL_R", "SHIFT_L", "SHIFT_R",
+     "WIN_L", "WIN_R", "MENU", "KP_ADD", "KP_SUBTRACT", "KP_END", "KP_DOWN",
+     "KP_PAGE_DOWN", "KP_LEFT", "KP_RIGHT", "KP_HOME", "KP_UP", "KP_PAGE_UP",
      "KP_INSERT", "KP_DELETE", "KP_5", "KP_ENTER", "KP_MULTIPLY", "KP_DIVIDE"
      };
 
@@ -128,7 +133,7 @@ static char tmp_key_name[40];
     if (key < sizeof(key_names)/sizeof(key_names[0]))
         sprintf (tmp_key_name, "SIM_KEY_%s", key_names[key]);
     else
-        sprintf (tmp_key_name, "UNKNOWN KEY: %d", key);
+        sprintf (tmp_key_name, "UNKNOWN KEY: %u", key);
     return tmp_key_name;
 }
 
@@ -170,9 +175,10 @@ static char tmp_key_name[40];
 #define amask 0xFF000000
 #endif
 
-/* libpng callbacks */ 
+/* libpng callbacks */
 static void png_error_SDL(png_structp ctx, png_const_charp str)
 {
+    UNUSED_ARG(ctx);
     SDL_SetError("libpng: %s\n", str);
 }
 static void png_write_SDL(png_structp png_ptr, png_bytep data, png_size_t length)
@@ -181,12 +187,13 @@ static void png_write_SDL(png_structp png_ptr, png_bytep data, png_size_t length
     SDL_RWwrite(rw, data, sizeof(png_byte), length);
 }
 
-static SDL_Surface *SDL_PNGFormatAlpha(SDL_Surface *src) 
+#if 0 /* Not used -- delete or save? */
+static SDL_Surface *SDL_PNGFormatAlpha(SDL_Surface *src)
 {
     SDL_Surface *surf;
     SDL_Rect rect = { 0 };
 
-    /* NO-OP for images < 32bpp and 32bpp images that already have Alpha channel */ 
+    /* NO-OP for images < 32bpp and 32bpp images that already have Alpha channel */
     if (src->format->BitsPerPixel <= 24 || src->format->Amask) {
         src->refcount++;
         return src;
@@ -201,8 +208,9 @@ static SDL_Surface *SDL_PNGFormatAlpha(SDL_Surface *src)
 
     return surf;
 }
+#endif
 
-static int SDL_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst) 
+static int SDL_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst)
 {
     png_structp png_ptr;
     png_infop info_ptr;
@@ -213,26 +221,26 @@ static int SDL_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst)
     png_bytep *row_pointers;
 #endif
     /* Initialize and do basic error checking */
-    if (!dst)
+    if (dst == NULL)
     {
         SDL_SetError("Argument 2 to SDL_SavePNG_RW can't be NULL, expecting SDL_RWops*\n");
         return (ERROR);
     }
-    if (!surface)
+    if (surface == NULL)
     {
         SDL_SetError("Argument 1 to SDL_SavePNG_RW can't be NULL, expecting SDL_Surface*\n");
         if (freedst) SDL_RWclose(dst);
         return (ERROR);
     }
     png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, png_error_SDL, NULL); /* err_ptr, err_fn, warn_fn */
-    if (!png_ptr) 
+    if (png_ptr == NULL)
     {
         SDL_SetError("Unable to png_create_write_struct on %s\n", PNG_LIBPNG_VER_STRING);
         if (freedst) SDL_RWclose(dst);
         return (ERROR);
     }
     info_ptr = png_create_info_struct(png_ptr);
-    if (!info_ptr)
+    if (info_ptr == NULL)
     {
         SDL_SetError("Unable to png_create_info_struct\n");
         png_destroy_write_struct(&png_ptr, NULL);
@@ -253,10 +261,10 @@ static int SDL_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst)
     colortype = PNG_COLOR_MASK_COLOR;
     if (surface->format->BytesPerPixel > 0
     &&  surface->format->BytesPerPixel <= 8
-    && (pal = surface->format->palette))
+    && (pal = surface->format->palette) != NULL)
     {
         colortype |= PNG_COLOR_MASK_PALETTE;
-        pal_ptr = (png_colorp)malloc(pal->ncolors * sizeof(png_color));
+        pal_ptr = (png_colorp) malloc(pal->ncolors * sizeof(png_color));
         for (i = 0; i < pal->ncolors; i++) {
             pal_ptr[i].red   = pal->colors[i].r;
             pal_ptr[i].green = pal->colors[i].g;
@@ -300,36 +308,65 @@ static int SDL_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst)
 }
 #endif /* defined(HAVE_LIBPNG) */
 
-/* 
-    Some platforms (OS X), require that ALL input event processing be 
+/*
+    Some platforms (OS X), require that ALL input event processing be
     performed by the main thread of the process.
 
-    To satisfy this requirement, we leverage the SDL_MAIN functionality 
+    To satisfy this requirement, we leverage the SDL_MAIN functionality
     which does:
-    
+
              #defines main SDL_main
-     
-     and we define the main() entry point here.  Locally, we run the 
+
+     and we define the main() entry point here.  Locally, we run the
      application's SDL_main in a separate thread, and while that thread
      is running, the main thread performs event handling and dispatch.
-     
+
+EVENT_OPEN, EVENT_OPENCOMPLETE: Previous implementation used a 20x100ms delay
+in the hope that the event thread would start and process the EVENT_OPEN
+message to initialize the simulator's video. The delay time is
+non-determinisitic due to accrued delays across OS thread scheduling latency,
+window subsystem initialization and other factors.  The current implementation
+uses a condition variable and associated mutex to signal EVENT_OPEN's
+completion.
+
+  - The thread that generates the EVENT_OPEN event initializes a startup
+    structure that contains the condition variable, queues the EVENT_OPEN event
+    and waits for the condition to signal.
+
+  - The SDL event loop processes the EVENT_OPEN, does all of the deferred
+    initialization, and queues EVENT_OPENCOMPLETE.
+
+  - EVENT_OPENCOMPLETE signals the condition variable and the SDL_CondWait()-ing
+    thread awakes.
+
+TODO: Fix asymmetry -- Event processing should be done in the main thread,
+SDL_main(). SDL_main() is available across all implementations, although that
+may not have been historically the case. SDL_main() should spawn the SIMH
+console CLI in its own thread.
  */
 
-#define EVENT_REDRAW      1                              /* redraw event for SDL */
-#define EVENT_CLOSE       2                              /* close event for SDL */
-#define EVENT_CURSOR      3                              /* new cursor for SDL */
-#define EVENT_WARP        4                              /* warp mouse position for SDL */
-#define EVENT_DRAW        5                              /* draw/blit region for SDL */
-#define EVENT_SHOW        6                              /* show SDL capabilities */
-#define EVENT_OPEN        7                              /* vid_open request */
-#define EVENT_EXIT        8                              /* program exit */
-#define EVENT_SCREENSHOT  9                              /* produce screenshot of video window */
-#define EVENT_BEEP       10                              /* audio beep */
-#define EVENT_FULLSCREEN 11                              /* fullscreen */
-#define EVENT_SIZE       12                              /* set window size */
+typedef enum SimhUserEvents_enum
+{
+    EVENT_UNUSED_0,
+    EVENT_CLOSE,                              /* close event for SDL */
+    EVENT_CURSOR,                             /* new cursor for SDL */
+    EVENT_WARP,                               /* warp mouse position for SDL */
+    EVENT_DRAW,                               /* draw/blit region for SDL */
+    EVENT_SHOW,                               /* show SDL capabilities */
+    EVENT_OPEN,                               /* vid_open request */
+    EVENT_OPENCOMPLETE,                       /* vid_open/SDL deferred init complete */
+    EVENT_EXIT,                               /* program exit */
+    EVENT_SCREENSHOT,                         /* produce screenshot of video window */
+    EVENT_BEEP,                               /* audio beep */
+    EVENT_FULLSCREEN,                         /* fullscreen */
+    EVENT_SIZE,                               /* set window size */
+
+    N_SIMH_USER_EVENTS                        /* Total event types. */
+} SimhUserEvents;
+
 #define MAX_EVENTS       20                              /* max events in queue */
 
-typedef struct {
+typedef struct KeyEventQueue_s {
     SIM_KEY_EVENT events[MAX_EVENTS];
     SDL_sem *sem;
     int32 head;
@@ -337,7 +374,7 @@ typedef struct {
     int32 count;
     } KEY_EVENT_QUEUE;
 
-typedef struct {
+typedef struct MouseEventQueue_s {
     SIM_MOUSE_EVENT events[MAX_EVENTS];
     SDL_sem *sem;
     int32 head;
@@ -346,12 +383,13 @@ typedef struct {
     } MOUSE_EVENT_QUEUE;
 
 int vid_thread (void* arg);
+
+/* Primary SDL event processing loop. */
 int vid_video_events (VID_DISPLAY *vptr);
-void vid_show_video_event (void);
-void vid_screenshot_event (void);
-void vid_beep_event (void);
+
 static void vid_beep_setup (int duration_ms, int tone_frequency);
 static void vid_beep_cleanup (void);
+
 static void vid_controllers_setup (DEVICE *dptr);
 static void vid_controllers_cleanup (void);
 
@@ -361,7 +399,7 @@ t_bool vid_mouse_captured;
 int32 vid_flags;                                        /* Open Flags */
 int32 vid_width;
 int32 vid_height;
-t_bool vid_ready;
+SDL_atomic_t vid_ready;
 char vid_title[128];
 SDL_Texture *vid_texture;                               /* video buffer in GPU */
 SDL_Renderer *vid_renderer;
@@ -380,6 +418,8 @@ SDL_Rect vid_rect;
 uint32 *vid_data_last;
 };
 
+SDL_atomic_t vid_active;                                /* == 0 -> inactive, crosses threads */
+
 SDL_Thread *vid_thread_handle = NULL;                   /* event thread handle */
 
 static VID_DISPLAY vid_first;
@@ -387,16 +427,145 @@ static VID_DISPLAY vid_first;
 KEY_EVENT_QUEUE vid_key_events;                         /* keyboard events */
 MOUSE_EVENT_QUEUE vid_mouse_events;                     /* mouse events */
 
-static VID_DISPLAY *vid_get_event_window (SDL_Event *ev, Uint32 windowID)
+/* Custom SDL user events:
+ *
+ * The redraw event is separate for easier filtering. */
+Uint32 simh_user_event = (Uint32) -1;                   /* SIMH's video (user) event */
+Uint32 simh_redraw_event = (Uint32) -1;                 /* Redraw event */
+
+/* Debugging pretty printers: */
+static void initWindowEventNames();
+static const char *getWindowEventName(Uint32 win_event);
+static void initEventNames();
+static const char *getEventName(Uint32 ev);
+static const char *getUserCodeName(Uint32 user_ev_code);
+
+static const char *eventtypes[SDL_LASTEVENT];
+static const char *windoweventtypes[256];
+static const char *userev_names[] = {
+    "(0 - unused)"
+    "EVENT_CLOSE",
+    "EVENT_CURSOR",
+    "EVENT_WARP",
+    "EVENT_DRAW",
+    "EVENT_SHOW",
+    "EVENT_OPEN",
+    "EVENT_OPENCOMPLETE",
+    "EVENT_EXIT",
+    "EVENT_SCREENSHOT",
+    "EVENT_BEEP",
+    "EVENT_FULLSCREEN",
+    "EVENT_SIZE"
+};
+
+
+/* Event handlers: */
+static void vid_null_user_event (SDL_UserEvent *ev, VID_DISPLAY *vptr);
+static void vid_beep_event (SDL_UserEvent *ev, VID_DISPLAY *vptr);
+static void vid_open_event (SDL_UserEvent *ev, VID_DISPLAY *ignored);
+static void vid_open_complete (SDL_UserEvent *, VID_DISPLAY *ignored);
+static void vid_update_cursor (SDL_UserEvent *ev, VID_DISPLAY *vptr);
+static void vid_warp_position (SDL_UserEvent *ev, VID_DISPLAY *vptr);
+static void vid_destroy (SDL_UserEvent *ev, VID_DISPLAY *vptr);
+static void vid_draw_region (SDL_UserEvent *event, VID_DISPLAY *vptr);
+static void vid_show_video_event (SDL_UserEvent *ev, VID_DISPLAY *vptr);
+static void vid_screenshot_event (SDL_UserEvent *ev, VID_DISPLAY *vptr);
+static void vid_fullscreen_event(SDL_UserEvent *ev, VID_DISPLAY *vptr);
+static void vid_size_event(SDL_UserEvent *ev, VID_DISPLAY *vptr0);
+static void vid_exit_event(SDL_UserEvent *ev, VID_DISPLAY *vptr);
+
+typedef struct SIMHUserEventHandler_s {
+    /* Function to which event is dispatched */
+    void (*handler)(SDL_UserEvent *ev, VID_DISPLAY *vptr);
+    /* SDL_TRUE => Requires non-NULL VID_DISPLAY. */
+    SDL_bool needs_vptr;
+} SIMHUserEventHandler;
+
+static const SIMHUserEventHandler simh_user_dispatch[N_SIMH_USER_EVENTS] =
+    {
+        { vid_null_user_event, SDL_FALSE },             /* EVENT_UNUSED_0 */
+        { vid_destroy, SDL_TRUE },                      /* EVENT_CLOSE */
+        { vid_update_cursor, SDL_TRUE },                /* EVENT_CURSOR */
+        { vid_warp_position, SDL_TRUE },                /* EVENT_WARP */
+        { vid_draw_region, SDL_TRUE },                  /* EVENT_DRAW */
+        { vid_show_video_event, SDL_FALSE },            /* EVENT_SHOW */
+        { vid_open_event, SDL_FALSE },                  /* EVENT_OPEN */
+        { vid_open_complete, SDL_FALSE },               /* EVENT_OPENCOMPLETE */
+        { vid_exit_event, SDL_FALSE },                  /* EVENT_EXIT */
+        { vid_screenshot_event, SDL_FALSE },            /* EVENT_SCREENSHOT */
+        { vid_beep_event, SDL_FALSE },                  /* EVENT_BEEP */
+        { vid_fullscreen_event, SDL_TRUE },             /* EVENT_FULLSCREEN */
+        { vid_size_event, SDL_TRUE }                    /* EVENT_SIZE */
+    };
+
+typedef struct SIMHDeferredRedraw_s {
+    VID_DISPLAY *vptr;
+    SDL_TimerID timer_id;
+    struct SIMHDeferredRedraw_s *next;
+} SIMHDeferredRedraw;
+
+static SIMHDeferredRedraw *vid_deferred_redraws = NULL;
+static SIMHDeferredRedraw *vid_deferred_freelist = NULL;
+static SDL_mutex *vid_deferred_mutex = NULL;
+static const SDL_TimerID invalid_timer_id = (Uint32) -1;
+
+/* Operations: */
+static SIMHDeferredRedraw *addDeferredRedraw(VID_DISPLAY *vptr, Uint32 delay);
+static void cancelDeferredRedraw(const VID_DISPLAY *vptr);
+/* SDL timer callback. */
+static Uint32 do_deferred_redraw(Uint32 interval, void *arg);
+
+/* Accessor function for vid_active.
+ *
+ * vid_active is used across threads, necessitating atomic operations (important
+ * on AARCH64.)
+ */
+int vid_is_active()
+{
+  return SDL_AtomicGet(&vid_active);
+}
+
+
+/* SIMH video initialization. Audio and joystick subsystems are initialized separately. */
+static int sim_video_system_init()
+{
+    int retval;
+
+    initWindowEventNames();
+    initEventNames();
+
+    SDL_AtomicSet(&vid_active, 0);
+
+    if ((retval = SDL_Init(SDL_INIT_EVENTS | SDL_INIT_VIDEO | SDL_INIT_TIMER)) >= 0) {
+        /* SDL_RegisterEvents() returns the first of the two event identifiers. */
+        simh_user_event = SDL_RegisterEvents(2);
+        simh_redraw_event = simh_user_event + 1;
+
+        if (simh_user_event == (Uint32) -1) {
+            fprintf (stderr, "SDL_RegisterEvents failed: %s\n", SDL_GetError ());
+            exit(1);
+        }
+
+        if (simh_user_event <= SDL_LASTEVENT - 2) {
+            eventtypes[simh_user_event] = "SIMH event";
+            eventtypes[simh_redraw_event] = "SIMH redraw";
+        }
+
+        /* Deferred redraw mutex. */
+        if ((vid_deferred_mutex = SDL_CreateMutex()) == NULL) {
+            retval = -1;
+        }
+    }
+
+    return retval;
+}
+
+
+static VID_DISPLAY *vid_get_event_window (Uint32 windowID)
 {
 static Uint32 lastID = 0xffffffff;
 static VID_DISPLAY *last_display = NULL;
 VID_DISPLAY *vptr;
-SDL_KeyboardEvent *kev;
-SDL_MouseButtonEvent *bev;
-SDL_MouseMotionEvent *mev;
-SDL_WindowEvent *wev;
-SDL_UserEvent *uev;
 
 if (windowID == lastID)
     return last_display;
@@ -404,16 +573,28 @@ if (windowID == lastID)
 for (vptr = &vid_first; vptr != NULL; vptr = vptr->next) {
     if (windowID == vptr->vid_windowID) {
         lastID = windowID;
-        return last_display = vptr;
+        last_display = vptr;
+        return vptr;
         }
     }
+
+return NULL;
+}
+
+static void reportUnrecognizedEvent(SDL_Event *ev)
+{
+SDL_KeyboardEvent *kev;
+SDL_MouseButtonEvent *bev;
+SDL_MouseMotionEvent *mev;
+SDL_WindowEvent *wev;
+SDL_UserEvent *uev;
 
 switch (ev->type) {
     case SDL_KEYDOWN:
     case SDL_KEYUP:
-        kev = (SDL_KeyboardEvent *)ev;
+        kev = &ev->key;
         sim_messagef (SCPE_OK, "Unrecognized key event.\n");
-        sim_messagef (SCPE_OK, "  type = %u\n", kev->type);
+        sim_messagef (SCPE_OK, "  type = %s\n", getEventName(ev->type));
         sim_messagef (SCPE_OK, "  timestamp = %u\n", kev->timestamp);
         sim_messagef (SCPE_OK, "  windowID = %u\n", kev->windowID);
         sim_messagef (SCPE_OK, "  state = %u\n", kev->state);
@@ -424,9 +605,9 @@ switch (ev->type) {
         break;
     case SDL_MOUSEBUTTONDOWN:
     case SDL_MOUSEBUTTONUP:
-        bev = (SDL_MouseButtonEvent *)ev;
+        bev = &ev->button;
         sim_messagef (SCPE_OK, "Unrecognized mouse button event.\n");
-        sim_messagef (SCPE_OK, "  type = %u\n", bev->type);
+        sim_messagef (SCPE_OK, "  type = %s\n", getEventName(ev->type));
         sim_messagef (SCPE_OK, "  timestamp = %u\n", bev->timestamp);
         sim_messagef (SCPE_OK, "  windowID = %u\n", bev->windowID);
         sim_messagef (SCPE_OK, "  which = %u\n", bev->which);
@@ -437,9 +618,9 @@ switch (ev->type) {
         sim_messagef (SCPE_OK, "  y = %d\n", bev->y);
         break;
     case SDL_MOUSEMOTION:
-        mev = (SDL_MouseMotionEvent *)ev;
+        mev = &ev->motion;
         sim_messagef (SCPE_OK, "Unrecognized mouse motion event.\n");
-        sim_messagef (SCPE_OK, "  type = %u\n", mev->type);
+        sim_messagef (SCPE_OK, "  type = %s\n", getEventName(ev->type));
         sim_messagef (SCPE_OK, "  timestamp = %u\n", mev->timestamp);
         sim_messagef (SCPE_OK, "  windowID = %u\n", mev->windowID);
         sim_messagef (SCPE_OK, "  which = %u\n", mev->which);
@@ -450,53 +631,99 @@ switch (ev->type) {
         sim_messagef (SCPE_OK, "  yrel = %d\n", mev->yrel);
         break;
     case SDL_WINDOWEVENT:
-        wev = (SDL_WindowEvent *)ev;
+        wev = &ev->window;
         sim_messagef (SCPE_OK, "Unrecognized window event.\n");
-        sim_messagef (SCPE_OK, "  type = %u\n", wev->type);
+        sim_messagef (SCPE_OK, "  type = %s\n", getEventName(ev->type));
         sim_messagef (SCPE_OK, "  timestamp = %u\n", wev->timestamp);
         sim_messagef (SCPE_OK, "  windowID = %u\n", wev->windowID);
-        sim_messagef (SCPE_OK, "  event = %u\n", wev->event);
-        sim_messagef (SCPE_OK, "  data1 = %d\n", wev->data1);
-        sim_messagef (SCPE_OK, "  data2 = %d\n", wev->data2);
+        sim_messagef (SCPE_OK, "  event = %s\n", getWindowEventName(wev->event));
+        sim_messagef (SCPE_OK, "  data1 = 0x%08x\n", wev->data1);
+        sim_messagef (SCPE_OK, "  data2 = 0x%08x\n", wev->data2);
         break;
     case SDL_USEREVENT:
-        uev = (SDL_UserEvent *)ev;
+        uev = &ev->user;
         sim_messagef (SCPE_OK, "Unrecognized user event.\n");
-        sim_messagef (SCPE_OK, "  type = %u\n", uev->type);
+        sim_messagef (SCPE_OK, "  type = %s\n", getEventName(uev->type));
         sim_messagef (SCPE_OK, "  timestamp = %u\n", uev->timestamp);
         sim_messagef (SCPE_OK, "  windowID = %u\n", uev->windowID);
-        sim_messagef (SCPE_OK, "  code = %d\n", uev->code);
-        sim_messagef (SCPE_OK, "  data1 = %p\n", uev->data1);
-        sim_messagef (SCPE_OK, "  data2 = %p\n", uev->data2);
+        sim_messagef (SCPE_OK, "  code = %s\n", getUserCodeName(uev->code));
+        sim_messagef (SCPE_OK, "  data1 = 0x%p\n", uev->data1);
+        sim_messagef (SCPE_OK, "  data2 = 0x%p\n", uev->data2);
         break;
     default:
         sim_messagef (SCPE_OK, "Unrecognized event type %u\n", ev->type);
         break;
     }
-
-sim_messagef (SCPE_OK,
-"\nSIMH has encountered a bug in SDL2.  An upgrade to SDL2\n"
-"version 2.0.14 should fix this problem.\n");
-
-return NULL;
 }
 
+/* Condition and mutex needed by EVENT_OPENCOMPLETE to signal that
+ * vid_video_events() or EVENT_OPEN has completed. */
+typedef struct sim_video_startup_t {
+    SDL_cond *startup_cond;
+    SDL_mutex *startup_mutex;
+} sim_video_startup_t;
+
+typedef struct sim_video_thread_arg_t {
+    VID_DISPLAY *vptr;
+    sim_video_startup_t *startup;
+} sim_video_thread_arg_t;
+
+
+static sim_video_startup_t *make_video_startup()
+{
+    sim_video_startup_t *retval = (sim_video_startup_t *) calloc(1, sizeof(sim_video_startup_t));
+
+    if (retval == NULL)
+        return retval;
+
+    retval->startup_cond = SDL_CreateCond();
+    if (NULL == retval->startup_cond) {
+        free(retval);
+        return NULL;
+    }
+
+    retval->startup_mutex = SDL_CreateMutex();
+    if (NULL == retval->startup_mutex) {
+        SDL_DestroyCond(retval->startup_cond);
+        free(retval);
+        return NULL;
+    }
+
+    return retval;
+}
+
+static void cleanup_video_startup(sim_video_startup_t **startup)
+{
+    if (NULL == *startup)
+        return;
+    if (NULL != (*startup)->startup_cond)
+        SDL_DestroyCond((*startup)->startup_cond);
+    if (NULL != (*startup)->startup_mutex)
+        SDL_DestroyMutex((*startup)->startup_mutex);
+    free(*startup);
+    *startup = NULL;
+}
+
+/* Need to fix this asymmetry: */
 #if defined (SDL_MAIN_AVAILABLE)
 #if defined (main)
 #undef main
 #endif
 
-static int main_argc;
-static char **main_argv;
-static SDL_Thread *vid_main_thread_handle;
+static int main_argc = -1;
+static char **main_argv = NULL;
+static SDL_Thread *vid_main_thread_handle = NULL;
 
+/* main_thread runs the CLI loop -- scp.c's main() is actually SDL_main(). */
 int main_thread (void *arg)
 {
 SDL_Event user_event;
 int stat;
 
+UNUSED_ARG(arg);
+
 stat = SDL_main (main_argc, main_argv);
-user_event.type = SDL_USEREVENT;
+user_event.type = simh_user_event;
 user_event.user.code = EVENT_EXIT;
 user_event.user.data1 = NULL;
 user_event.user.data2 = NULL;
@@ -520,9 +747,7 @@ SDL_SetHint (SDL_HINT_RENDER_DRIVER, "software");
 SDL_SetHint (SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
 #endif
 
-status = SDL_Init (SDL_INIT_EVENTS);
-
-if (status) {
+if (sim_video_system_init()) {
     fprintf (stderr, "SDL Video subsystem can't initialize: %s\n", SDL_GetError ());
     exit (1);
     }
@@ -539,21 +764,34 @@ vid_beep_setup (400, 660);
 memset (&event, 0, sizeof (event));
 
 while (1) {
-    int status = SDL_WaitEvent (&event);
+    status = SDL_WaitEvent (&event);
     if (status == 1) {
-        if (event.type == SDL_USEREVENT) {
+        if (event.type == simh_user_event) {
             if (event.user.code == EVENT_EXIT)
                 break;
             if (event.user.code == EVENT_OPEN) {
-                SDL_Init (SDL_INIT_VIDEO);
+                sim_video_startup_t *startup = (sim_video_startup_t *) event.user.data2;
+                SDL_Event startup_event;
+
+                /* Push EVENT_OPENCOMPLETE onto the event queue so that
+                 * vid_video_events() sees it because we're handling EVENT_OPEN
+                 * here, and video startup signals correctly.
+                 */
+                startup_event.type = simh_user_event;
+                startup_event.user.code = EVENT_OPENCOMPLETE;
+                startup_event.user.data1 = startup;
+                startup_event.user.data2 = NULL;
+                SDL_PushEvent(&startup_event);
+
+                /* vid_video_events() returns on EVENT_EXIT or error. */
                 vid_video_events ((VID_DISPLAY *)event.user.data1);
             }
             else {
                 if (event.user.code == EVENT_SHOW)
-                    vid_show_video_event ();
+                    vid_show_video_event (&event.user, NULL);
                 else {
                     if (event.user.code == EVENT_SCREENSHOT)
-                        vid_screenshot_event ();
+                        vid_screenshot_event (&event.user, NULL);
                     else {
                         sim_printf ("main(): Unexpected User event: %d\n", event.user.code);
                         break;
@@ -578,19 +816,25 @@ return status;
 
 static t_stat vid_create_window (VID_DISPLAY *vptr)
 {
-int wait_count = 0;
 SDL_Event user_event;
+sim_video_startup_t *startup = make_video_startup();
 
-vptr->vid_ready = FALSE;
-user_event.type = SDL_USEREVENT;
+SDL_LockMutex(startup->startup_mutex);
+
+SDL_AtomicSet(&vptr->vid_ready, FALSE);
+user_event.type = simh_user_event;
 user_event.user.code = EVENT_OPEN;
 user_event.user.data1 = vptr;
-user_event.user.data2 = NULL;
+user_event.user.data2 = startup;
 SDL_PushEvent (&user_event);
 
-while ((!vptr->vid_ready) && (++wait_count < 20))
-    sim_os_ms_sleep (100);
-if (!vptr->vid_ready) {
+/* EVENT_OPENCOMPLETE event signals that vid_open() has completed
+ * deferred initialization. */
+SDL_CondWait(startup->startup_cond, startup->startup_mutex);
+SDL_UnlockMutex(startup->startup_mutex);
+cleanup_video_startup(&startup);
+
+if (SDL_AtomicGet(&vptr->vid_ready) == FALSE) {
     vid_close ();
     return SCPE_OPENERR;
     }
@@ -599,27 +843,37 @@ return SCPE_OK;
 #else
 static int vid_create_window (VID_DISPLAY *vptr)
 {
-int wait_count = 0;
+sim_video_startup_t *startup = make_video_startup();
+sim_video_thread_arg_t arg = { vptr, startup };
 
-if (vid_thread_handle == NULL)
-    vid_thread_handle = SDL_CreateThread (vid_thread, "vid-thread", vptr);
-else {
+SDL_LockMutex(startup->startup_mutex);
+
+if (vid_thread_handle == NULL) {
+    vid_thread_handle = SDL_CreateThread (vid_thread, "vid-thread", &arg);
+} else {
     SDL_Event user_event;
-    vptr->vid_ready = FALSE;
-    user_event.type = SDL_USEREVENT;
+
+    SDL_AtomicSet(&vptr->vid_ready, FALSE);
+    user_event.type = simh_user_event;
     user_event.user.code = EVENT_OPEN;
     user_event.user.data1 = vptr;
-    user_event.user.data2 = NULL;
+    user_event.user.data2 = startup;
     SDL_PushEvent (&user_event);
     }
 
 if (vid_thread_handle == NULL) {
+    cleanup_video_startup(&startup);
     vid_close ();
     return SCPE_OPENERR;
     }
-while ((!vptr->vid_ready) && (++wait_count < 20))
-    sim_os_ms_sleep (100);
-if (!vptr->vid_ready) {
+
+/* EVENT_OPENCOMPLETE event signals that vid_open() has completed
+ * deferred initialization. */
+SDL_CondWait(startup->startup_cond, startup->startup_mutex);
+SDL_UnlockMutex(startup->startup_mutex);
+cleanup_video_startup(&startup);
+
+if (SDL_AtomicGet(&vptr->vid_ready) == FALSE) {
     vid_close ();
     return SCPE_OPENERR;
     }
@@ -669,7 +923,7 @@ n = SDL_NumJoysticks();
 
 for (i = 0; i < n; i++) {
     if (vid_gamepad_ok && SDL_IsGameController (i)) {
-        SDL_GameController *x = SDL_GameControllerOpen (i);
+        const SDL_GameController *x = SDL_GameControllerOpen (i);
         if (x != NULL) {
             sim_debug (SIM_VID_DBG_VIDEO, dev,
             "Game controller: %s\n", SDL_GameControllerNameForIndex(i));
@@ -716,9 +970,9 @@ vptr->vid_height = height;
 vptr->vid_mouse_captured = FALSE;
 vptr->vid_cursor_visible = (vptr->vid_flags & SIM_VID_INPUTCAPTURED);
 vptr->vid_blending = FALSE;
-vptr->vid_ready = FALSE;
+SDL_AtomicSet(&vptr->vid_ready, FALSE);
 
-if (!vid_active) {
+if (SDL_AtomicGet(&vid_active) == 0) {
     vid_key_events.head = 0;
     vid_key_events.tail = 0;
     vid_key_events.count = 0;
@@ -738,7 +992,7 @@ stat = vid_create_window (vptr);
 if (stat != SCPE_OK)
     return stat;
 
-sim_debug (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE, vptr->vid_dev, "vid_open() - Success\n");
+sim_debug (SIM_VID_DBG_ALL, vptr->vid_dev, "vid_open() - Success\n");
 
 return SCPE_OK;
 }
@@ -773,9 +1027,9 @@ t_stat vid_close_window (VID_DISPLAY *vptr)
 SDL_Event user_event;
 int status;
 
-if (vptr->vid_ready) {
-    sim_debug (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE, vptr->vid_dev, "vid_close()\n");
-    user_event.type = SDL_USEREVENT;
+if (SDL_AtomicGet(&vptr->vid_ready) != FALSE) {
+    sim_debug (SIM_VID_DBG_ALL, vptr->vid_dev, "vid_close()\n");
+    user_event.type = simh_user_event;
     user_event.user.windowID = vptr->vid_windowID;
     user_event.user.code = EVENT_CLOSE;
     user_event.user.data1 = NULL;
@@ -785,19 +1039,19 @@ if (vptr->vid_ready) {
         sim_os_ms_sleep (10);
     vptr->vid_dev = NULL;
     }
-if (vid_thread_handle && vid_active <= 1) {
+if (vid_thread_handle && SDL_AtomicGet(&vid_active) <= 1) {
     SDL_WaitThread (vid_thread_handle, &status);
     vid_thread_handle = NULL;
     }
-while (vptr->vid_ready)
+while (SDL_AtomicGet(&vptr->vid_ready) != FALSE)
     sim_os_ms_sleep (10);
 
 vptr->vid_active_window = FALSE;
-if (!vid_active && vid_mouse_events.sem) {
+if (SDL_AtomicGet(&vid_active) == 0 && vid_mouse_events.sem) {
     SDL_DestroySemaphore(vid_mouse_events.sem);
     vid_mouse_events.sem = NULL;
     }
-if (!vid_active && vid_key_events.sem) {
+if (SDL_AtomicGet(&vid_active) == 0 && vid_key_events.sem) {
     SDL_DestroySemaphore(vid_key_events.sem);
     vid_key_events.sem = NULL;
     }
@@ -839,22 +1093,24 @@ return SCPE_EOF;
 t_stat vid_poll_mouse (SIM_MOUSE_EVENT *ev)
 {
 t_stat stat = SCPE_EOF;
-SIM_MOUSE_EVENT *nev;
 
 if (SDL_SemTryWait (vid_mouse_events.sem) == 0) {
     if (vid_mouse_events.count > 0) {
+        const SIM_MOUSE_EVENT *mev;
+
         stat = SCPE_OK;
         *ev = vid_mouse_events.events[vid_mouse_events.head++];
         vid_mouse_events.count--;
         if (vid_mouse_events.head == MAX_EVENTS)
             vid_mouse_events.head = 0;
-        nev = &vid_mouse_events.events[vid_mouse_events.head];
+
+        mev = &vid_mouse_events.events[vid_mouse_events.head];
         if ((vid_mouse_events.count > 0) &&
-            (0 == (ev->x_rel + nev->x_rel)) &&
-            (0 == (ev->y_rel + nev->y_rel)) &&
-            (ev->b1_state == nev->b1_state) &&
-            (ev->b2_state == nev->b2_state) &&
-            (ev->b3_state == nev->b3_state)) {
+            (0 == (ev->x_rel + mev->x_rel)) &&
+            (0 == (ev->y_rel + mev->y_rel)) &&
+            (ev->b1_state == mev->b1_state) &&
+            (ev->b2_state == mev->b2_state) &&
+            (ev->b3_state == mev->b3_state)) {
             if ((++vid_mouse_events.head) == MAX_EVENTS)
                 vid_mouse_events.head = 0;
             vid_mouse_events.count--;
@@ -886,15 +1142,16 @@ return SDL_MapRGBA (vptr->vid_format, r, g, b, a);
 void vid_draw_window (VID_DISPLAY *vptr, int32 x, int32 y, int32 w, int32 h, uint32 *buf)
 {
 SDL_Event user_event;
-SDL_Rect *vid_dst, *last;
+SDL_Rect *vid_dst;
+const SDL_Rect *last;
 uint32 *vid_data;
 
 sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "vid_draw(%d, %d, %d, %d)\n", x, y, w, h);
 
 SDL_LockMutex (vptr->vid_draw_mutex);                         /* Synchronize to check region dimensions */
 last = vptr->vid_dst_last;
-if (last                               &&               /* As yet unprocessed draw rectangle? */
-    (last->x == x) && (last->y == y) &&                 /* AND identical position? */
+if (last != NULL                       &&               /* As yet unprocessed draw rectangle? */
+    (last->x == x) && (last->y == y)   &&               /* AND identical position? */
     (last->w == w) && (last->h == h)) {                 /* AND identical dimensions? */
     memcpy (vptr->vid_data_last, buf, w*h*sizeof(*buf));/* Replace region contents */
     SDL_UnlockMutex (vptr->vid_draw_mutex);                   /* Done */
@@ -918,7 +1175,7 @@ if (!vid_data) {
     return;
     }
 memcpy (vid_data, buf, w*h*sizeof(*buf));
-user_event.type = SDL_USEREVENT;
+user_event.type = simh_user_event;
 user_event.user.windowID = vptr->vid_windowID;
 user_event.user.code = EVENT_DRAW;
 user_event.user.data1 = (void *)vid_dst;
@@ -961,7 +1218,7 @@ if (sim_deb) {
         }
     }
 
-user_event.type = SDL_USEREVENT;
+user_event.type = simh_user_event;
 user_event.user.windowID = vptr->vid_windowID;
 user_event.user.code = EVENT_CURSOR;
 user_event.user.data1 = cursor;
@@ -990,7 +1247,7 @@ if (vptr->vid_flags & SIM_VID_INPUTCAPTURED)
 
 if ((x_delta) || (y_delta)) {
     sim_debug (SIM_VID_DBG_CURSOR, vptr->vid_dev, "vid_set_cursor_position(%d, %d) - Cursor position changed\n", x, y);
-    /* Any queued mouse motion events need to have their relative 
+    /* Any queued mouse motion events need to have their relative
        positions adjusted since they were queued based on different info. */
     if (SDL_SemWait (vid_mouse_events.sem) == 0) {
         int32 i;
@@ -1013,7 +1270,7 @@ if ((x_delta) || (y_delta)) {
     if (vptr->vid_cursor_visible) {
         SDL_Event user_event;
 
-        user_event.type = SDL_USEREVENT;
+        user_event.type = simh_user_event;
         user_event.user.windowID = vptr->vid_windowID;
         user_event.user.code = EVENT_WARP;
         user_event.user.data1 = NULL;
@@ -1036,18 +1293,25 @@ vid_set_cursor_position_window (&vid_first, x, y);
 
 void vid_refresh_window (VID_DISPLAY *vptr)
 {
-SDL_Event user_event;
+SIMHDeferredRedraw *p;
 
-sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "vid_refresh() - Queueing Refresh Event\n");
+for (p = vid_deferred_redraws; p != NULL && p->vptr != vptr; p = p->next) /* NOP */;
 
-user_event.type = SDL_USEREVENT;
-user_event.user.windowID = vptr->vid_windowID;
-user_event.user.code = EVENT_REDRAW;
-user_event.user.data1 = NULL;
-user_event.user.data2 = NULL;
+if (p == NULL) {
+    SDL_Event user_event = {
+        .user.type = simh_redraw_event,
+        .user.windowID = vptr->vid_windowID,
+        .user.code = 0,
+        .user.data1 = vptr,
+        .user.data2 = NULL
+    };
 
-if (SDL_PushEvent (&user_event) < 0)
-    sim_printf ("%s: vid_refresh() SDL_PushEvent error: %s\n", vid_dname(vptr->vid_dev), SDL_GetError());
+    sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "vid_refresh_window() - Queueing refresh event\n");
+    if (SDL_PushEvent (&user_event) < 0)
+        sim_printf ("%s: vid_refresh_window() SDL_PushEvent error: %s\n", vid_dname(vptr->vid_dev), SDL_GetError());
+} else {
+    sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "vid_refresh_window() - Pending deferred refresh event\n");
+    }
 }
 
 void vid_refresh (void)
@@ -1432,10 +1696,11 @@ void vid_controller_button (SDL_ControllerButtonEvent *event)
 
 void vid_key (SDL_KeyboardEvent *event)
 {
-SIM_KEY_EVENT ev;
-VID_DISPLAY *vptr = vid_get_event_window ((SDL_Event *)event, event->windowID);
-if (vptr == NULL)
-   return;
+VID_DISPLAY *vptr = vid_get_event_window (event->windowID);
+if (vptr == NULL) {
+    reportUnrecognizedEvent((SDL_Event *) event);
+    return;
+    }
 
 if (vptr->vid_mouse_captured) {
     static const Uint8 *KeyStates = NULL;
@@ -1443,9 +1708,9 @@ if (vptr->vid_mouse_captured) {
 
     if (!KeyStates)
         KeyStates = SDL_GetKeyboardState(&numkeys);
-    if ((vptr->vid_flags & SIM_VID_INPUTCAPTURED) && 
-        (event->state == SDL_PRESSED) && 
-        KeyStates[SDL_SCANCODE_RSHIFT] && 
+    if ((vptr->vid_flags & SIM_VID_INPUTCAPTURED) &&
+        (event->state == SDL_PRESSED) &&
+        KeyStates[SDL_SCANCODE_RSHIFT] &&
         (KeyStates[SDL_SCANCODE_LCTRL] || KeyStates[SDL_SCANCODE_RCTRL])) {
         sim_debug (SIM_VID_DBG_KEY, vptr->vid_dev, "vid_key() - Cursor Release\n");
         if (SDL_SetRelativeMouseMode(SDL_FALSE) < 0)    /* release cursor, show cursor */
@@ -1458,6 +1723,8 @@ if (!sim_is_running)
     return;
 if (SDL_SemWait (vid_key_events.sem) == 0) {
     if (vid_key_events.count < MAX_EVENTS) {
+        SIM_KEY_EVENT ev;
+    
         ev.key = vid_map_key (event->keysym.sym);
         ev.dev = vptr->vid_dev;
         ev.vptr = vptr;
@@ -1490,11 +1757,11 @@ if (SDL_SemWait (vid_key_events.sem) == 0) {
 void vid_mouse_move (SDL_MouseMotionEvent *event)
 {
 SDL_Event dummy_event;
-SDL_MouseMotionEvent *dev = (SDL_MouseMotionEvent *)&dummy_event;
-SIM_MOUSE_EVENT ev;
-VID_DISPLAY *vptr = vid_get_event_window ((SDL_Event *)event, event->windowID);
-if (vptr == NULL)
-   return;
+VID_DISPLAY *vptr = vid_get_event_window (event->windowID);
+if (vptr == NULL) {
+    reportUnrecognizedEvent((SDL_Event *)event);
+    return;
+    }
 
 if ((!vptr->vid_mouse_captured) && (vptr->vid_flags & SIM_VID_INPUTCAPTURED))
     return;
@@ -1503,16 +1770,18 @@ if (!sim_is_running)
     return;
 if (!vptr->vid_cursor_visible)
     return;
-sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Move Event: pos:(%d,%d) rel:(%d,%d) buttons:(%d,%d,%d)\n", 
+sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Move Event: pos:(%d,%d) rel:(%d,%d) buttons:(%d,%d,%d)\n",
            event->x, event->y, event->xrel, event->yrel, (event->state & SDL_BUTTON(SDL_BUTTON_LEFT)) ? 1 : 0, (event->state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) ? 1 : 0, (event->state & SDL_BUTTON(SDL_BUTTON_RIGHT)) ? 1 : 0);
 while (SDL_PeepEvents (&dummy_event, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION)) {
+    SDL_MouseMotionEvent *dev = (SDL_MouseMotionEvent *)&dummy_event;
+
     /* Coalesce motion activity to avoid thrashing */
     event->xrel += dev->xrel;
     event->yrel += dev->yrel;
     event->x = dev->x;
     event->y = dev->y;
     event->state = dev->state;
-    sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Move Event: Additional Event Coalesced:pos:(%d,%d) rel:(%d,%d) buttons:(%d,%d,%d)\n", 
+    sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Move Event: Additional Event Coalesced:pos:(%d,%d) rel:(%d,%d) buttons:(%d,%d,%d)\n",
         dev->x, dev->y, dev->xrel, dev->yrel, (dev->state & SDL_BUTTON(SDL_BUTTON_LEFT)) ? 1 : 0, (dev->state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) ? 1 : 0, (dev->state & SDL_BUTTON(SDL_BUTTON_RIGHT)) ? 1 : 0);
     };
 if (SDL_SemWait (vid_mouse_events.sem) == 0) {
@@ -1523,28 +1792,31 @@ if (SDL_SemWait (vid_mouse_events.sem) == 0) {
     vid_mouse_b1 = (event->state & SDL_BUTTON(SDL_BUTTON_LEFT)) ? TRUE : FALSE;
     vid_mouse_b2 = (event->state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) ? TRUE : FALSE;
     vid_mouse_b3 = (event->state & SDL_BUTTON(SDL_BUTTON_RIGHT)) ? TRUE : FALSE;
-    sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Move Event: pos:(%d,%d) rel:(%d,%d) buttons:(%d,%d,%d) - Count: %d vid_cursor:(%d,%d)\n", 
+    sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Move Event: pos:(%d,%d) rel:(%d,%d) buttons:(%d,%d,%d) - Count: %d vid_cursor:(%d,%d)\n",
                                             event->x, event->y, event->xrel, event->yrel, (event->state & SDL_BUTTON(SDL_BUTTON_LEFT)) ? 1 : 0, (event->state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) ? 1 : 0, (event->state & SDL_BUTTON(SDL_BUTTON_RIGHT)) ? 1 : 0, vid_mouse_events.count, vid_cursor_x, vid_cursor_y);
     if (vid_mouse_events.count < MAX_EVENTS) {
         SIM_MOUSE_EVENT *tail = &vid_mouse_events.events[(vid_mouse_events.tail+MAX_EVENTS-1)%MAX_EVENTS];
+        SIM_MOUSE_EVENT ev;
 
-        ev.dev = vptr->vid_dev;
         ev.x_rel = event->xrel;
         ev.y_rel = event->yrel;
+        ev.x_pos = event->x;
+        ev.y_pos = event->y;
         ev.b1_state = vid_mouse_b1;
         ev.b2_state = vid_mouse_b2;
         ev.b3_state = vid_mouse_b3;
-        ev.x_pos = event->x;
-        ev.y_pos = event->y;
+        ev.dev = vptr->vid_dev;
+        ev.vptr = vptr;
+
         if ((vid_mouse_events.count > 0) &&             /* Is there a tail event? */
             (ev.b1_state == tail->b1_state) &&          /* With the same button state? */
-            (ev.b2_state == tail->b2_state) && 
+            (ev.b2_state == tail->b2_state) &&
             (ev.b3_state == tail->b3_state)) {          /* Merge the motion */
             tail->x_rel += ev.x_rel;
             tail->y_rel += ev.y_rel;
             tail->x_pos = ev.x_pos;
             tail->y_pos = ev.y_pos;
-            sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Move Event: Coalesced into pending event: (%d,%d)\n", 
+            sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Move Event: Coalesced into pending event: (%d,%d)\n",
                 tail->x_rel, tail->y_rel);
             }
         else {                                          /* Add a new event */
@@ -1567,9 +1839,11 @@ void vid_mouse_button (SDL_MouseButtonEvent *event)
 SDL_Event dummy_event;
 SIM_MOUSE_EVENT ev;
 t_bool state;
-VID_DISPLAY *vptr = vid_get_event_window ((SDL_Event *)event, event->windowID);
-if (vptr == NULL)
-   return;
+VID_DISPLAY *vptr = vid_get_event_window (event->windowID);
+if (vptr == NULL) {
+    reportUnrecognizedEvent((SDL_Event *)event);
+    return;
+    }
 
 if ((!vptr->vid_mouse_captured) && (vptr->vid_flags & SIM_VID_INPUTCAPTURED)) {
     if ((event->state == SDL_PRESSED) &&
@@ -1601,7 +1875,6 @@ if (SDL_SemWait (vid_mouse_events.sem) == 0) {
             }
     sim_debug (SIM_VID_DBG_MOUSE, vptr->vid_dev, "Mouse Button Event: State: %d, Button: %d, (%d,%d)\n", event->state, event->button, event->x, event->y);
     if (vid_mouse_events.count < MAX_EVENTS) {
-        ev.dev = vptr->vid_dev;
         ev.x_rel = 0;
         ev.y_rel = 0;
         ev.x_pos = event->x;
@@ -1609,6 +1882,9 @@ if (SDL_SemWait (vid_mouse_events.sem) == 0) {
         ev.b1_state = vid_mouse_b1;
         ev.b2_state = vid_mouse_b2;
         ev.b3_state = vid_mouse_b3;
+        ev.dev = vptr->vid_dev;
+        ev.vptr = vptr;
+
         vid_mouse_events.events[vid_mouse_events.tail++] = ev;
         vid_mouse_events.count++;
         if (vid_mouse_events.tail == MAX_EVENTS)
@@ -1624,17 +1900,19 @@ if (SDL_SemWait (vid_mouse_events.sem) == 0) {
 
 void vid_set_window_size (VID_DISPLAY *vptr, int32 w, int32 h)
 {
-SDL_Event user_event;
-
 vptr->vid_rect.h = h;
 vptr->vid_rect.w = w;
 
-user_event.type = SDL_USEREVENT;
+#if defined (SDL_MAIN_AVAILABLE)
+/* This declaration is legitimate C99 (and later) */
+SDL_Event user_event;
+
+user_event.type = simh_user_event;
 user_event.user.windowID = vptr->vid_windowID;
 user_event.user.code = EVENT_SIZE;
 user_event.user.data1 = NULL;
 user_event.user.data2 = NULL;
-#if defined (SDL_MAIN_AVAILABLE)
+
 while (SDL_PushEvent (&user_event) < 0)
     sim_os_ms_sleep (100);
 #else
@@ -1654,14 +1932,15 @@ return vid_is_fullscreen_window (&vid_first);
 
 t_stat vid_set_fullscreen_window (VID_DISPLAY *vptr, t_bool flag)
 {
+#if defined (SDL_MAIN_AVAILABLE)
 SDL_Event user_event;
 
-user_event.type = SDL_USEREVENT;
+user_event.type = simh_user_event;
 user_event.user.windowID = vptr->vid_windowID;
 user_event.user.code = EVENT_FULLSCREEN;
 user_event.user.data1 = (flag) ? vptr : NULL;
 user_event.user.data2 = NULL;
-#if defined (SDL_MAIN_AVAILABLE)
+
 while (SDL_PushEvent (&user_event) < 0)
     sim_os_ms_sleep (100);
 #else
@@ -1724,11 +2003,15 @@ else {
     }
 }
 
-void vid_update_cursor (VID_DISPLAY *vptr, SDL_Cursor *cursor, t_bool visible)
+static void vid_update_cursor (SDL_UserEvent *ev, VID_DISPLAY *vptr)
 {
-if (!cursor)
+SDL_Cursor *cursor = (SDL_Cursor *) ev->data1;
+t_bool visible = (t_bool) ((size_t) ev->data2);
+
+if (cursor == NULL)
     return;
-sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "Cursor Update Event: Previously %s, Now %s, New Cursor object at: %p, Old Cursor object at: %p\n", 
+
+sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "Cursor Update Event: Previously %s, Now %s, New Cursor object at: %p, Old Cursor object at: %p\n",
                             SDL_ShowCursor(-1) ? "visible" : "invisible", visible ? "visible" : "invisible", cursor, vptr->vid_cursor);
 SDL_SetCursor (cursor);
 if ((vptr->vid_window == SDL_GetMouseFocus ()) && visible)
@@ -1740,8 +2023,10 @@ SDL_ShowCursor (visible);
 vptr->vid_cursor_visible = visible;
 }
 
-void vid_warp_position (VID_DISPLAY *vptr)
+static void vid_warp_position (SDL_UserEvent *ev, VID_DISPLAY *vptr)
 {
+UNUSED_ARG(ev);
+
 sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "Mouse Warp Event: Warp to: (%d,%d)\n", vid_cursor_x, vid_cursor_y);
 
 SDL_PumpEvents ();
@@ -1749,7 +2034,7 @@ SDL_WarpMouseInWindow (NULL, vid_cursor_x, vid_cursor_y);
 SDL_PumpEvents ();
 }
 
-void vid_draw_region (VID_DISPLAY *vptr, SDL_UserEvent *event)
+static void vid_draw_region (SDL_UserEvent *event, VID_DISPLAY *vptr)
 {
 SDL_Rect *vid_dst = (SDL_Rect *)event->data1;
 uint32 *buf = (uint32 *)event->data2;
@@ -1765,7 +2050,7 @@ SDL_UnlockMutex (vptr->vid_draw_mutex);
 
 if (vptr->vid_blending) {
     SDL_UpdateTexture(vptr->vid_texture, vid_dst, buf, vid_dst->w*sizeof(*buf));
-    SDL_RenderCopy (vptr->vid_renderer, vptr->vid_texture, vid_dst, vid_dst); 
+    SDL_RenderCopy (vptr->vid_renderer, vptr->vid_texture, vid_dst, vid_dst);
     }
 else
     if (SDL_UpdateTexture(vptr->vid_texture, vid_dst, buf, vid_dst->w*sizeof(*buf)))
@@ -1841,7 +2126,7 @@ memset (&vptr->vid_key_state, 0, sizeof(vptr->vid_key_state));
 vptr->vid_dst_last = NULL;
 vptr->vid_data_last = NULL;
 
-vid_active++;
+SDL_AtomicIncRef(&vid_active);
 return 1;
 }
 
@@ -1875,11 +2160,24 @@ if (SDL_SetRenderDrawBlendMode (vptr->vid_renderer, x))
 return SCPE_OK;
 }
 
-static void vid_destroy (VID_DISPLAY *vptr)
+/* SIMH user event handlers: */
+
+/* Null (no-op) user event handler. */
+static void vid_null_user_event (SDL_UserEvent *ev, VID_DISPLAY *vptr)
+{
+    UNUSED_ARG(ev);
+    UNUSED_ARG(vptr);
+}
+
+static void vid_destroy (SDL_UserEvent *ev, VID_DISPLAY *vptr)
 {
 VID_DISPLAY *parent;
-vptr->vid_ready = FALSE;
-if (vptr->vid_cursor) {
+
+UNUSED_ARG(ev);
+
+SDL_AtomicSet(&vptr->vid_ready, FALSE);
+cancelDeferredRedraw(vptr);
+if (vptr->vid_cursor != NULL) {
     SDL_FreeCursor (vptr->vid_cursor);
     vptr->vid_cursor = NULL;
     }
@@ -1895,133 +2193,251 @@ for (parent = &vid_first; parent != NULL; parent = parent->next) {
     if (parent->next == vptr)
         parent->next = vptr->next;
     }
-vid_active--;
+
+SDL_AtomicDecRef(&vid_active);
+}
+
+static void vid_open_event(SDL_UserEvent *ev, VID_DISPLAY *ignored)
+{
+    VID_DISPLAY *vptr = (VID_DISPLAY *) ev->data1;
+    sim_video_startup_t *startup = (sim_video_startup_t *) ev->data2;
+    SDL_Event startup_event;
+
+    UNUSED_ARG(ignored);
+
+    vid_new_window (vptr);
+    SDL_AtomicSet(&vptr->vid_ready, TRUE);
+
+    startup_event.type = simh_user_event;
+    startup_event.user.code = EVENT_OPENCOMPLETE;
+    startup_event.user.data1 = startup;
+    startup_event.user.data2 = NULL;
+    SDL_PushEvent(&startup_event);
+}
+
+static void vid_open_complete(SDL_UserEvent *ev, VID_DISPLAY *ignored)
+{
+    UNUSED_ARG(ignored);
+
+    /* EVENT_OPEN has completed, release the condition */
+    sim_video_startup_t *startup = (sim_video_startup_t *) ev->data1;
+    SDL_CondSignal(startup->startup_cond);
+}
+
+static void vid_fullscreen_event(SDL_UserEvent *ev, VID_DISPLAY *vptr)
+{
+    if (ev->data1 != NULL)
+        SDL_SetWindowFullscreen (vptr->vid_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+    else
+        SDL_SetWindowFullscreen (vptr->vid_window, 0);
+}
+
+static void vid_size_event(SDL_UserEvent *ev, VID_DISPLAY *vptr)
+{
+    UNUSED_ARG(ev);
+    SDL_SetWindowSize (vptr->vid_window, vptr->vid_rect.w, vptr->vid_rect.h);
+}
+
+static void vid_exit_event(SDL_UserEvent *ev, VID_DISPLAY *vptr)
+{
+    /* C99 initialization style. */
+    SDL_Event quit_ev = {
+        .quit.type = SDL_QUIT
+    };
+
+    UNUSED_ARG(ev);
+    UNUSED_ARG(vptr);
+
+    /* vid_video_events() loop terminates. */
+    SDL_AtomicSet(&vid_active, 0);
+    /* Quit event. */
+    SDL_PushEvent(&quit_ev);
+}
+
+static void vid_redraw_event(SDL_UserEvent *ev, VID_DISPLAY *ignored)
+{
+    /* Last SDL_GetTicks() time when we saw a redraw. */
+    static Uint32 redraw_last = 0;
+    /* Frame interval (30 fps interval in milliseconds), minus a 2 ms fudge
+     * factor. SDL_WaitEvent() (actually SDL_WaitEventTimeout()) looks for
+     * events on 1 ms intervals, so the redraw could be late by 2ms. Being early
+     * isn't necessarily an issue. 
+     * 
+     * 30 fps is the human visual perception rate.
+     */
+    const Sint32 frame_interval = (1000 / 30) - 2;
+    /* Current number of ms since SDL_Init(). */
+    Uint32 ticks_now;
+    VID_DISPLAY *vptr = (VID_DISPLAY *) ev->data1;
+
+    UNUSED_ARG(ignored);
+
+    /* Invalid VID_DISPLAY? */
+    if (vptr == NULL || SDL_AtomicGet(&vptr->vid_ready) == FALSE)
+      return;
+
+    /* Push through this update. */
+    vid_update (vptr);
+
+    ticks_now = SDL_GetTicks();
+    if (SDL_TICKS_PASSED(ticks_now, redraw_last) < frame_interval) {
+        SDL_Event peek_events[32];
+        const int n_peek_events = sizeof(peek_events) / sizeof(peek_events[0]);
+        int       n_peek;
+
+        /* Coalesce redraw events belonging to this display and schedule a future redraw
+         * event. SDL2 recommends invoking SDL_PumpEvents() before calling SDL_PeekEvents(),
+         * so we do.
+         */
+        SDL_PumpEvents();
+        n_peek = SDL_PeepEvents (peek_events, n_peek_events, SDL_GETEVENT,
+                                 simh_redraw_event, simh_redraw_event);
+        if (n_peek > 0) {
+            int    n_pulled    = 0;
+            size_t i;
+
+            for (i = 0; i < (size_t) n_peek; ++i) {
+                if (ev->windowID == peek_events[i].user.windowID) {
+                    ++n_pulled;
+                } else {
+                    /* Put the other window's redraw back onto the queue. */
+                    SDL_PushEvent(&peek_events[i]);
+                }
+            }
+
+            if (n_pulled > 0) {
+                Uint32 delay = frame_interval - SDL_TICKS_PASSED(ticks_now, redraw_last);
+
+                /* There is a future redraw event. */
+                sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev,
+                           "simh_redraw_event - Coalesced %d redraw events\n", n_pulled);
+
+                if (addDeferredRedraw(vptr, delay) == NULL) {
+                    sim_messagef(SCPE_MEM, "Could not add deferred redraw event for windowID %d\n",
+                                 ev->windowID);
+                }
+   
+            }
+        }
+    }
+
+    redraw_last = ticks_now;
+}
+
+static void debugDeferredLists(DEVICE *dev)
+{
+    if (sim_deb != NULL && dev != NULL && (dev->dctrl & SIM_VID_DBG_VIDEO)) {
+        int n_free = 0, n_defer = 0;
+        const SIMHDeferredRedraw *p;
+
+        for (p = vid_deferred_redraws;  p != NULL; ++n_defer, p = p->next) /* NOP */;
+        for (p = vid_deferred_freelist; p != NULL; ++n_free,  p = p->next) /* NOP */;
+        _sim_debug_device (SIM_VID_DBG_VIDEO, dev,
+                           "vid_deferred_redraws = %d, vid_deferred_freelist = %d\n", n_defer, n_free);
+    }
+}
+
+static SIMHDeferredRedraw *addDeferredRedraw(VID_DISPLAY *vptr, Uint32 delay)
+{
+    SIMHDeferredRedraw *p;
+
+    SDL_LockMutex(vid_deferred_mutex);
+
+    for (p = vid_deferred_redraws; p != NULL; p = p->next) {
+        if (p->vptr == vptr) {
+            sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "simh_redraw_event - already deferred refresh.\n");
+            goto done;                  /* Already scheduled. */
+        }
+    }
+
+    if (vid_deferred_freelist != NULL) {
+        p = vid_deferred_freelist;
+        vid_deferred_freelist = vid_deferred_freelist->next;
+        if (p->timer_id != invalid_timer_id) {
+            /* Remove the timer here, not inside the callback. */
+            SDL_RemoveTimer(p->timer_id);
+            p->timer_id = invalid_timer_id;
+        }
+
+        p->next = NULL;
+    } else {
+        if ((p = (SIMHDeferredRedraw *) calloc(1, sizeof(SIMHDeferredRedraw))) == NULL)
+            goto done;
+    }
+
+    p->vptr = vptr;
+    p->timer_id = SDL_AddTimer(delay, do_deferred_redraw, p);
+    p->next = vid_deferred_redraws;
+    vid_deferred_redraws = p;
+    sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "simh_redraw_event - deferring redraw for %u ms\n",
+               delay);
+
+done:
+    debugDeferredLists(vptr->vid_dev);
+    SDL_UnlockMutex(vid_deferred_mutex);
+    return p;
+}
+
+static SIMHDeferredRedraw *removeDeferredRedraw(const VID_DISPLAY *vptr)
+{
+    SIMHDeferredRedraw *p, *q;
+
+    for (p = q = vid_deferred_redraws; p != NULL; q = p, p = p->next) {
+        if (p->vptr == vptr) {
+            if (q == vid_deferred_redraws)
+                vid_deferred_redraws = NULL;
+            else
+                q->next = p->next;
+            p->next = vid_deferred_freelist;
+            vid_deferred_freelist = p;
+            break;
+        }
+    }
+
+    debugDeferredLists(vptr->vid_dev);
+
+    return p;
+}
+
+static void cancelDeferredRedraw(const VID_DISPLAY *vptr)
+{
+    SIMHDeferredRedraw *p;
+
+    SDL_LockMutex(vid_deferred_mutex);
+    p = removeDeferredRedraw(vptr);
+    if (p != NULL && p->timer_id != invalid_timer_id) {
+        SDL_RemoveTimer(p->timer_id);
+        p->timer_id = invalid_timer_id;
+    }
+    SDL_UnlockMutex(vid_deferred_mutex);
+}
+
+static Uint32 do_deferred_redraw(Uint32 interval, void *arg)
+{
+    SIMHDeferredRedraw *redraw = (SIMHDeferredRedraw *) arg;
+
+    UNUSED_ARG(interval);
+
+    sim_debug (SIM_VID_DBG_VIDEO, redraw->vptr->vid_dev, "do_deferred_redraw: timer triggered.\n");
+
+    SDL_LockMutex(vid_deferred_mutex);
+    /* Back to the freelist... */
+    removeDeferredRedraw(redraw->vptr);
+    SDL_UnlockMutex(vid_deferred_mutex);
+
+    /* Queue the redraw event... */
+    vid_refresh_window(redraw->vptr);
+
+    /* Don't retrigger the redraw. (Future: Maybe we do want to retrigger the redraw at the
+     * frame_interval? If we do, don't cleanup the timers.) */
+    return 0;
 }
 
 int vid_video_events (VID_DISPLAY *vptr0)
 {
 SDL_Event event;
-static const char *eventtypes[SDL_LASTEVENT];
-static const char *windoweventtypes[256];
-static t_bool initialized = FALSE;
 
-if (!initialized) {
-    initialized = TRUE;
-
-    eventtypes[SDL_QUIT] = "QUIT";          /**< User-requested quit */
-
-    /* These application events have special meaning on iOS, see README-ios.txt for details */
-    eventtypes[SDL_APP_TERMINATING] = "APP_TERMINATING";   /**< The application is being terminated by the OS
-                                     Called on iOS in applicationWillTerminate()
-                                     Called on Android in onDestroy()
-                                */
-    eventtypes[SDL_APP_LOWMEMORY] = "APP_LOWMEMORY";          /**< The application is low on memory, free memory if possible.
-                                     Called on iOS in applicationDidReceiveMemoryWarning()
-                                     Called on Android in onLowMemory()
-                                */
-    eventtypes[SDL_APP_WILLENTERBACKGROUND] = "APP_WILLENTERBACKGROUND"; /**< The application is about to enter the background
-                                     Called on iOS in applicationWillResignActive()
-                                     Called on Android in onPause()
-                                */
-    eventtypes[SDL_APP_DIDENTERBACKGROUND] = "APP_DIDENTERBACKGROUND"; /**< The application did enter the background and may not get CPU for some time
-                                     Called on iOS in applicationDidEnterBackground()
-                                     Called on Android in onPause()
-                                */
-    eventtypes[SDL_APP_WILLENTERFOREGROUND] = "APP_WILLENTERFOREGROUND"; /**< The application is about to enter the foreground
-                                     Called on iOS in applicationWillEnterForeground()
-                                     Called on Android in onResume()
-                                */
-    eventtypes[SDL_APP_DIDENTERFOREGROUND] = "APP_DIDENTERFOREGROUND"; /**< The application is now interactive
-                                     Called on iOS in applicationDidBecomeActive()
-                                     Called on Android in onResume()
-                                */
-
-    /* Window events */
-    eventtypes[SDL_WINDOWEVENT] = "WINDOWEVENT"; /**< Window state change */
-    eventtypes[SDL_SYSWMEVENT] = "SYSWMEVENT";             /**< System specific event */
-
-    windoweventtypes[SDL_WINDOWEVENT_NONE] = "NONE";                /**< Never used */
-    windoweventtypes[SDL_WINDOWEVENT_SHOWN] = "SHOWN";              /**< Window has been shown */
-    windoweventtypes[SDL_WINDOWEVENT_HIDDEN] = "HIDDEN";            /**< Window has been hidden */
-    windoweventtypes[SDL_WINDOWEVENT_EXPOSED] = "EXPOSED";          /**< Window has been exposed and should be
-                                                                         redrawn */
-    windoweventtypes[SDL_WINDOWEVENT_MOVED] = "MOVED";              /**< Window has been moved to data1, data2
-                                     */
-    windoweventtypes[SDL_WINDOWEVENT_RESIZED] = "RESIZED";          /**< Window has been resized to data1xdata2 */
-    windoweventtypes[SDL_WINDOWEVENT_SIZE_CHANGED] = "SIZE_CHANGED";/**< The window size has changed, either as a result of an API call or through the system or user changing the window size. */
-    windoweventtypes[SDL_WINDOWEVENT_MINIMIZED] = "MINIMIZED";      /**< Window has been minimized */
-    windoweventtypes[SDL_WINDOWEVENT_MAXIMIZED] = "MAXIMIZED";      /**< Window has been maximized */
-    windoweventtypes[SDL_WINDOWEVENT_RESTORED] = "RESTORED";        /**< Window has been restored to normal size
-                                                                         and position */
-    windoweventtypes[SDL_WINDOWEVENT_ENTER] = "ENTER";              /**< Window has gained mouse focus */
-    windoweventtypes[SDL_WINDOWEVENT_LEAVE] = "LEAVE";              /**< Window has lost mouse focus */
-    windoweventtypes[SDL_WINDOWEVENT_FOCUS_GAINED] = "FOCUS_GAINED";/**< Window has gained keyboard focus */
-    windoweventtypes[SDL_WINDOWEVENT_FOCUS_LOST] = "FOCUS_LOST";    /**< Window has lost keyboard focus */
-    windoweventtypes[SDL_WINDOWEVENT_CLOSE] = "CLOSE";              /**< The window manager requests that the
-                                                                         window be closed */
-
-    /* Keyboard events */
-    eventtypes[SDL_KEYDOWN] = "KEYDOWN";                            /**< Key pressed */
-    eventtypes[SDL_KEYUP] = "KEYUP";                                /**< Key released */
-    eventtypes[SDL_TEXTEDITING] = "TEXTEDITING";                    /**< Keyboard text editing (composition) */
-    eventtypes[SDL_TEXTINPUT] = "TEXTINPUT";                        /**< Keyboard text input */
-
-    /* Mouse events */
-    eventtypes[SDL_MOUSEMOTION] = "MOUSEMOTION";                    /**< Mouse moved */
-    eventtypes[SDL_MOUSEBUTTONDOWN] = "MOUSEBUTTONDOWN";            /**< Mouse button pressed */
-    eventtypes[SDL_MOUSEBUTTONUP] = "MOUSEBUTTONUP";                /**< Mouse button released */
-    eventtypes[SDL_MOUSEWHEEL] = "MOUSEWHEEL";                      /**< Mouse wheel motion */
-
-    /* Joystick events */
-    eventtypes[SDL_JOYAXISMOTION] = "JOYAXISMOTION";                /**< Joystick axis motion */
-    eventtypes[SDL_JOYBALLMOTION] = "JOYBALLMOTION";                /**< Joystick trackball motion */
-    eventtypes[SDL_JOYHATMOTION] = "JOYHATMOTION";                  /**< Joystick hat position change */
-    eventtypes[SDL_JOYBUTTONDOWN] = "JOYBUTTONDOWN";                /**< Joystick button pressed */
-    eventtypes[SDL_JOYBUTTONUP] = "JOYBUTTONUP";                    /**< Joystick button released */
-    eventtypes[SDL_JOYDEVICEADDED] = "JOYDEVICEADDED";              /**< A new joystick has been inserted into the system */
-    eventtypes[SDL_JOYDEVICEREMOVED] = "JOYDEVICEREMOVED";          /**< An opened joystick has been removed */
-
-    /* Game controller events */
-    eventtypes[SDL_CONTROLLERAXISMOTION] = "CONTROLLERAXISMOTION";          /**< Game controller axis motion */
-    eventtypes[SDL_CONTROLLERBUTTONDOWN] = "CONTROLLERBUTTONDOWN";          /**< Game controller button pressed */
-    eventtypes[SDL_CONTROLLERBUTTONUP] = "CONTROLLERBUTTONUP";              /**< Game controller button released */
-    eventtypes[SDL_CONTROLLERDEVICEADDED] = "CONTROLLERDEVICEADDED";        /**< A new Game controller has been inserted into the system */
-    eventtypes[SDL_CONTROLLERDEVICEREMOVED] = "CONTROLLERDEVICEREMOVED";    /**< An opened Game controller has been removed */
-    eventtypes[SDL_CONTROLLERDEVICEREMAPPED] = "CONTROLLERDEVICEREMAPPED";  /**< The controller mapping was updated */
-
-    /* Touch events */
-    eventtypes[SDL_FINGERDOWN] = "FINGERDOWN";
-    eventtypes[SDL_FINGERUP] = "FINGERUP";
-    eventtypes[SDL_FINGERMOTION] = "FINGERMOTION";
-
-    /* Gesture events */
-    eventtypes[SDL_DOLLARGESTURE] = "DOLLARGESTURE";
-    eventtypes[SDL_DOLLARRECORD] = "DOLLARRECORD";
-    eventtypes[SDL_MULTIGESTURE] = "MULTIGESTURE";
-
-    /* Clipboard events */
-    eventtypes[SDL_CLIPBOARDUPDATE] = "CLIPBOARDUPDATE"; /**< The clipboard changed */
-
-    /* Drag and drop events */
-    eventtypes[SDL_DROPFILE] = "DROPFILE"; /**< The system requests a file open */
-
-#if (SDL_MINOR_VERSION > 0) || (SDL_PATCHLEVEL >= 3)
-    /* Render events */
-    eventtypes[SDL_RENDER_TARGETS_RESET] = "RENDER_TARGETS_RESET"; /**< The render targets have been reset */
-#endif
-
-#if (SDL_MINOR_VERSION > 0) || (SDL_PATCHLEVEL >= 4)
-    /* Render events */
-    eventtypes[SDL_RENDER_DEVICE_RESET] = "RENDER_DEVICE_RESET"; /**< The render device has been reset */
-#endif
-
-    /** Events ::SDL_USEREVENT through ::SDL_LASTEVENT are for your use,
-     *  and should be allocated with SDL_RegisterEvents()
-     */
-    eventtypes[SDL_USEREVENT] = "USEREVENT";
-    }
-
-sim_debug (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE, vptr0->vid_dev, "vid_thread() - Starting\n");
+sim_debug (SIM_VID_DBG_ALL, vptr0->vid_dev, "vid_video_events() - Starting\n");
 
 sim_os_set_thread_priority (PRIORITY_ABOVE_NORMAL);
 
@@ -2032,10 +2448,10 @@ if (!vid_new_window (vptr0)) {
 vid_beep_setup (400, 660);
 vid_controllers_setup (vptr0->vid_dev);
 
-vptr0->vid_ready = TRUE;
-sim_debug (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE|SIM_VID_DBG_CURSOR, vptr0->vid_dev, "vid_thread() - Started\n");
+SDL_AtomicSet(&vptr0->vid_ready, TRUE);
+sim_debug (SIM_VID_DBG_ALL, vptr0->vid_dev, "vid_video_events() - Started\n");
 
-while (vid_active) {
+while (SDL_AtomicGet(&vid_active) != 0) {
     int status = SDL_WaitEvent (&event);
     if (status == 1) {
         VID_DISPLAY *vptr;
@@ -2074,9 +2490,10 @@ while (vid_active) {
                 break;
 
             case SDL_WINDOWEVENT:
-                vptr = vid_get_event_window (&event, event.window.windowID);
+                vptr = vid_get_event_window (event.window.windowID);
                 if (vptr != NULL) {
-                    sim_debug (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE|SIM_VID_DBG_CURSOR, vptr->vid_dev, "vid_thread() - Window Event: %d - %s\n", event.window.event, windoweventtypes[event.window.event]);
+                    sim_debug (SIM_VID_DBG_ALL, vptr->vid_dev, "vid_video_events() - Window Event: %d - %s\n",
+                               event.window.event, getWindowEventName(event.window.event));
                     switch (event.window.event) {
                         case SDL_WINDOWEVENT_ENTER:
                              if (vptr->vid_flags & SIM_VID_INPUTCAPTURED)
@@ -2086,132 +2503,71 @@ while (vid_active) {
                             vid_update (vptr);
                             break;
                         default:
-                            sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "Did not handle window event: %d - %s\n", event.window.event, windoweventtypes[event.window.event]);
+                            sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "Did not handle window event: %d - %s\n",
+                                       event.window.event, getWindowEventName(event.window.event));
                             break;
                         }
+                    }
+                else {
+                    reportUnrecognizedEvent(&event);
                     }
                 break;
 
             case SDL_USEREVENT:
-                /* There are 11 user events generated */
-                /* EVENT_REDRAW      to update the display */
-                /* EVENT_DRAW        to update a region in the display texture */
-                /* EVENT_SHOW        to display the current SDL video capabilities */
-                /* EVENT_CURSOR      to change the current cursor */
-                /* EVENT_WARP        to warp the cursor position */
-                /* EVENT_OPEN        to open a new window */
-                /* EVENT_CLOSE       to wake up this thread and let */
-                /*                   it notice vid_active has changed */
-                /* EVENT_SCREENSHOT  to take a screenshot */
-                /* EVENT_BEEP        to emit a beep sound */
-                /* EVENT_SIZE        to change screen size */
-                /* EVENT_FULLSCREEN  to change fullscreen */
-                while (vid_active && event.user.code) {
-                    /* Handle Beep first since it isn't a window oriented event */
-                    if (event.user.code == EVENT_BEEP) {
-                        vid_beep_event ();
-                        event.user.code = 0;    /* Mark as done */
-                        continue;
-                        }
-                    if (event.user.code != EVENT_OPEN) {
-                        vptr = vid_get_event_window (&event, event.user.windowID);
-                        if (vptr == NULL) {
-                            sim_printf ("vid_thread() - Ignored event not bound to a window\n");
-                            event.user.code = 0;    /* Mark as done */
-                            break;
-                        }
-                    }
-                    if (event.user.code == EVENT_REDRAW) {
-                        vid_update (vptr);
-                        event.user.code = 0;    /* Mark as done */
-                        while (SDL_PeepEvents (&event, 1, SDL_GETEVENT, SDL_USEREVENT, SDL_USEREVENT)) {
-                            if ((event.user.code == EVENT_REDRAW) &&
-                                (vptr == vid_get_event_window (&event, event.user.windowID))) {
-                                /* Only do a single video update to the same window between waiting for events */
-                                sim_debug (SIM_VID_DBG_VIDEO, vptr->vid_dev, "vid_thread() - Ignored extra REDRAW Event\n");
-                                event.user.code = 0;    /* Mark as done */
-                                continue;
-                                }
-                            vptr = vid_get_event_window (&event, event.user.windowID);
-                            break;
+            default:
+                if (event.type == simh_user_event) {
+                    if (event.user.code >= EVENT_CLOSE && event.user.code <= EVENT_SIZE) {
+                        const SIMHUserEventHandler *dispatch = &simh_user_dispatch[event.user.code];
+
+                        vptr = NULL;
+                        if (dispatch->needs_vptr != SDL_TRUE || (vptr = vid_get_event_window (event.user.windowID)) != NULL) {
+                            (*dispatch->handler)(&event.user, vptr);
+                            }
+                        else {
+                            /* needs_vptr == SDL_TRUE && vptr == NULL */
+                            sim_printf ("simh_user_event - Expected a window, ignored.\n");
+                            reportUnrecognizedEvent(&event);
                             }
                         }
-                    if (event.user.code == EVENT_CURSOR) {
-                        vid_update_cursor (vptr, (SDL_Cursor *)(event.user.data1), (t_bool)((size_t)event.user.data2));
-                        event.user.data1 = NULL;
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_WARP) {
-                        vid_warp_position (vptr);
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_CLOSE) {
-                        vid_destroy (vptr);
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_DRAW) {
-                        vid_draw_region (vptr, (SDL_UserEvent*)&event);
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_SHOW) {
-                        vid_show_video_event ();
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_SCREENSHOT) {
-                        vid_screenshot_event ();
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_SIZE) {
-                        SDL_SetWindowSize (vptr->vid_window, vptr->vid_rect.w, vptr->vid_rect.h);
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_FULLSCREEN) {
-                        if (event.user.data1 != NULL)
-                            SDL_SetWindowFullscreen (vptr->vid_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-                        else
-                            SDL_SetWindowFullscreen (vptr->vid_window, 0);
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_BEEP) {
-                        vid_beep_event ();
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code == EVENT_OPEN) {
-                        VID_DISPLAY *vptr = (VID_DISPLAY *)event.user.data1;
-                        vid_new_window (vptr);
-                        vptr->vid_ready = TRUE;
-                        event.user.code = 0;    /* Mark as done */
-                        }
-                    if (event.user.code != 0) {
-                        sim_printf ("vid_thread(): Unexpected user event code: %d\n", event.user.code);
+                    else {
+                        sim_printf ("simh_user_event: Unexpected user event");
+                        reportUnrecognizedEvent(&event);
                         }
                     }
-                break;
-            case SDL_QUIT:
-                sim_debug (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE|SIM_VID_DBG_CURSOR, vptr0->vid_dev, "vid_thread() - QUIT Event - %s\n", vid_quit_callback ? "Signaled" : "Ignored");
-                if (vid_quit_callback)
-                    vid_quit_callback ();
+                else if (event.type == simh_redraw_event) {
+                    vid_redraw_event(&event.user, NULL);
+                    }
+                else {
+                    sim_debug (SIM_VID_DBG_ALL, vptr0->vid_dev, "vid_video_events() - Ignored Event: Type: %s (%04x)\n",
+                        getEventName(event.type), event.type);
+                    }
                 break;
 
-            default:
-                sim_debug (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE|SIM_VID_DBG_CURSOR, vptr0->vid_dev, "vid_thread() - Ignored Event: Type: %s(%d)\n", eventtypes[event.type], event.type);
+            case SDL_QUIT:
+                sim_debug (SIM_VID_DBG_ALL, vptr0->vid_dev,
+                           "vid_video_events() - QUIT Event - %s\n", vid_quit_callback ? "Signaled" : "Ignored");
+                if (vid_quit_callback)
+                    vid_quit_callback ();
                 break;
             }
         }
     else {
         if (status < 0)
-            sim_printf ("%s: vid_thread() - SDL_WaitEvent error: %s\n", vid_dname(vptr0->vid_dev), SDL_GetError());
+            sim_printf ("%s: vid_video_events() - SDL_WaitEvent error: %s\n", vid_dname(vptr0->vid_dev), SDL_GetError());
         }
     }
 vid_controllers_cleanup ();
 vid_beep_cleanup ();
-sim_debug (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE|SIM_VID_DBG_CURSOR, vptr0->vid_dev, "vid_thread() - Exiting\n");
+sim_debug (SIM_VID_DBG_ALL, vptr0->vid_dev, "vid_video_events() - Exiting\n");
 return 0;
 }
 
 int vid_thread (void *arg)
 {
-VID_DISPLAY *vptr = (VID_DISPLAY *)arg;
+sim_video_thread_arg_t *thread_arg = (sim_video_thread_arg_t *) arg;
+VID_DISPLAY *vptr = thread_arg->vptr;
+sim_video_startup_t *startup = thread_arg->startup;
+SDL_Event startup_event;
 int stat;
 
 SDL_SetHint (SDL_HINT_RENDER_DRIVER, "software");
@@ -2221,12 +2577,23 @@ SDL_SetHint (SDL_HINT_RENDER_DRIVER, "software");
 SDL_SetHint (SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
 #endif
 
-stat = SDL_Init (SDL_INIT_VIDEO);
-
+stat = sim_video_system_init();
 if (stat) {
     sim_printf ("SDL Video subsystem can't initialize\n");
     return 0;
     }
+
+/* Push EVENT_OPENCOMPLETE onto the event queue so that vid_video_events() because
+ * EVENT_OPEN is not actually sent to the queue.
+ *
+ * This is asymmetric with the "normal" EVENT_OPEN protocol.
+ * */
+startup_event.type = simh_user_event;
+startup_event.user.code = EVENT_OPENCOMPLETE;
+startup_event.user.data1 = startup;
+startup_event.user.data2 = NULL;
+SDL_PushEvent(&startup_event);
+
 vid_video_events (vptr);
 SDL_Quit ();
 return 0;
@@ -2245,10 +2612,10 @@ SDLVersion[sizeof (SDLVersion) - 1] = '\0';
 if ((compiled.major == running.major) &&
     (compiled.minor == running.minor) &&
     (compiled.patch == running.patch))
-    snprintf(SDLVersion, sizeof (SDLVersion) - 1, "SDL Version %d.%d.%d", 
+    snprintf(SDLVersion, sizeof (SDLVersion) - 1, "SDL Version %d.%d.%d",
                         compiled.major, compiled.minor, compiled.patch);
 else
-    snprintf(SDLVersion, sizeof (SDLVersion) - 1, "SDL Version (Compiled: %d.%d.%d, Runtime: %d.%d.%d)", 
+    snprintf(SDLVersion, sizeof (SDLVersion) - 1, "SDL Version (Compiled: %d.%d.%d, Runtime: %d.%d.%d)",
                         compiled.major, compiled.minor, compiled.patch,
                         running.major, running.minor, running.patch);
 #if defined (HAVE_LIBPNG)
@@ -2256,19 +2623,19 @@ if (1) {
     png_structp png = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 
     if (strcmp (PNG_LIBPNG_VER_STRING, png_get_libpng_ver (png)))
-        snprintf(&SDLVersion[strlen (SDLVersion)], sizeof (SDLVersion) - (strlen (SDLVersion) + 1), 
-                            ", PNG Version (Compiled: %s, Runtime: %s)", 
+        snprintf(&SDLVersion[strlen (SDLVersion)], sizeof (SDLVersion) - (strlen (SDLVersion) + 1),
+                            ", PNG Version (Compiled: %s, Runtime: %s)",
                             PNG_LIBPNG_VER_STRING, png_get_libpng_ver (png));
     else
-        snprintf(&SDLVersion[strlen (SDLVersion)], sizeof (SDLVersion) - (strlen (SDLVersion) + 1), 
+        snprintf(&SDLVersion[strlen (SDLVersion)], sizeof (SDLVersion) - (strlen (SDLVersion) + 1),
                             ", PNG Version %s", PNG_LIBPNG_VER_STRING);
     png_destroy_read_struct(&png, NULL, NULL);
 #if defined (ZLIB_VERSION)
     if (strcmp (ZLIB_VERSION, zlibVersion ()))
-        snprintf(&SDLVersion[strlen (SDLVersion)], sizeof (SDLVersion) - (strlen (SDLVersion) + 1), 
+        snprintf(&SDLVersion[strlen (SDLVersion)], sizeof (SDLVersion) - (strlen (SDLVersion) + 1),
                             ", zlib: (Compiled: %s, Runtime: %s)", ZLIB_VERSION, zlibVersion ());
     else
-        snprintf(&SDLVersion[strlen (SDLVersion)], sizeof (SDLVersion) - (strlen (SDLVersion) + 1), 
+        snprintf(&SDLVersion[strlen (SDLVersion)], sizeof (SDLVersion) - (strlen (SDLVersion) + 1),
                             ", zlib: %s", ZLIB_VERSION);
 #endif
     }
@@ -2278,12 +2645,22 @@ return (const char *)SDLVersion;
 
 t_stat vid_set_release_key (FILE* st, UNIT* uptr, int32 val, CONST void* desc)
 {
+UNUSED_ARG(st);
+UNUSED_ARG(uptr);
+UNUSED_ARG(val);
+UNUSED_ARG(desc);
+
 return SCPE_NOFNC;
 }
 
 t_stat vid_show_release_key (FILE* st, UNIT* uptr, int32 val, CONST void* desc)
 {
 VID_DISPLAY *vptr;
+
+UNUSED_ARG(uptr);
+UNUSED_ARG(val);
+UNUSED_ARG(desc);
+
 for (vptr = &vid_first; vptr != NULL; vptr = vptr->next) {
     if (vptr->vid_flags & SIM_VID_INPUTCAPTURED) {
         fprintf (st, "ReleaseKey=%s", vid_release_key);
@@ -2302,10 +2679,9 @@ fprintf (st, "Video support using SDL: %s\n", vid_version());
 #if defined (SDL_MAIN_AVAILABLE)
 fprintf (st, "  SDL Events being processed on the main process thread\n");
 #endif
-if (!vid_active) {
+if (SDL_AtomicGet(&vid_active) == 0) {
 #if !defined (SDL_MAIN_AVAILABLE)
-    int stat = SDL_Init(SDL_INIT_VIDEO);
-
+    int stat = sim_video_system_init();
     if (stat)
         return sim_messagef (SCPE_OPENERR, "SDL_Init() failed.  Video subsystem is unavailable.\n");
 #endif
@@ -2340,7 +2716,7 @@ for (i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
         }
     else {
         uint32 j, k;
-        static struct {uint32 format; const char *name;} PixelFormats[] = {
+        static const struct {uint32 format; const char *name;} PixelFormats[] = {
             {SDL_PIXELFORMAT_INDEX1LSB,     "Index1LSB"},
             {SDL_PIXELFORMAT_INDEX1MSB,     "Index1MSB"},
             {SDL_PIXELFORMAT_INDEX4LSB,     "Index4LSB"},
@@ -2376,7 +2752,8 @@ for (i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
             {SDL_PIXELFORMAT_YUY2,          "YUY2"},
             {SDL_PIXELFORMAT_UYVY,          "UYVY"},
             {SDL_PIXELFORMAT_YVYU,          "YVYU"},
-            {SDL_PIXELFORMAT_UNKNOWN,       "Unknown"}};
+            {SDL_PIXELFORMAT_UNKNOWN,       "Unknown"}
+        };
 
         fprintf (st, "     Render #%d - %s\n", i, info.name);
         fprintf (st, "        Flags: 0x%X - ", info.flags);
@@ -2393,7 +2770,7 @@ for (i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
             fprintf (st, "        Max Texture: %d by %d\n", info.max_texture_height, info.max_texture_width);
         fprintf (st, "        Pixel Formats:\n");
         for (j=0; j<info.num_texture_formats; j++) {
-            for (k=0; 1; k++) {
+            for (k=0; k < sizeof(PixelFormats) / sizeof(PixelFormats[0]); k++) {
                 if (PixelFormats[k].format == info.texture_formats[j]) {
                     fprintf (st, "            %s\n", PixelFormats[k].name);
                     break;
@@ -2406,7 +2783,7 @@ for (i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
             }
         }
     }
-if (vid_active) {
+if (SDL_AtomicGet(&vid_active) != 0) {
     SDL_RendererInfo info;
 
     info.name = "";
@@ -2519,46 +2896,51 @@ if (1) {
         }
     }
 #if !defined (SDL_MAIN_AVAILABLE)
-if (!vid_active)
+if (SDL_AtomicGet(&vid_active) == 0)
     SDL_Quit();
 #endif
 return SCPE_OK;
 }
 
-static t_stat _show_stat;
+static SDL_atomic_t _show_stat;
 static FILE *_show_st;
 static UNIT *_show_uptr;
 static int32 _show_val;
 static CONST void *_show_desc;
 
-void vid_show_video_event (void)
+static void vid_show_video_event (SDL_UserEvent *ev, VID_DISPLAY *vptr)
 {
-_show_stat = _vid_show_video (_show_st, _show_uptr, _show_val, _show_desc);
+UNUSED_ARG(ev);
+UNUSED_ARG(vptr);
+
+SDL_AtomicSet(&_show_stat, _vid_show_video (_show_st, _show_uptr, _show_val, _show_desc));
 }
 
 t_stat vid_show_video (FILE* st, UNIT* uptr, int32 val, CONST void* desc)
 {
 SDL_Event user_event;
 
-_show_stat = -1;
+SDL_AtomicSet(&_show_stat, -1);
 _show_st = st;
 _show_uptr = uptr;
 _show_val = val;
 _show_desc = desc;
 
-user_event.type = SDL_USEREVENT;
+user_event.type = simh_user_event;
 user_event.user.code = EVENT_SHOW;
 user_event.user.data1 = NULL;
 user_event.user.data2 = NULL;
+
 #if defined (SDL_MAIN_AVAILABLE)
-while (SDL_PushEvent (&user_event) < 0)
-    sim_os_ms_sleep (10);
-#else
-vid_show_video_event ();
-#endif
-while (_show_stat == -1)
+SDL_PushEvent (&user_event);
+
+while (SDL_AtomicGet(&_show_stat) == -1)
     SDL_Delay (20);
-return _show_stat;
+#else
+vid_show_video_event (&user_event.user, NULL);
+#endif
+
+return SDL_AtomicGet(&_show_stat);
 }
 
 static t_stat _vid_screenshot (VID_DISPLAY *vptr, const char *filename)
@@ -2566,7 +2948,7 @@ static t_stat _vid_screenshot (VID_DISPLAY *vptr, const char *filename)
 int stat;
 char *fullname = NULL;
 
-if (!vid_active) {
+if (SDL_AtomicGet(&vid_active) == 0) {
     sim_printf ("No video display is active\n");
     return SCPE_UDIS | SCPE_NOMESSAGE;
     }
@@ -2605,19 +2987,24 @@ else {
     }
 }
 
-static t_stat _screenshot_stat;
+static SDL_atomic_t _screenshot_stat;
 static const char *_screenshot_filename;
 
-void vid_screenshot_event (void)
+static void vid_screenshot_event (SDL_UserEvent *ev, VID_DISPLAY *ignored)
 {
 VID_DISPLAY *vptr;
-int i = 0, n;
+int i = 0;
+size_t n;
 char *name = (char *)malloc (strlen (_screenshot_filename) + 5);
-char *extension = strrchr ((char *)_screenshot_filename, '.');
+const char *extension = strrchr ((char *)_screenshot_filename, '.');
+
+UNUSED_ARG(ev);
+UNUSED_ARG(ignored);
+
 if (name == NULL) {
-    _screenshot_stat = SCPE_NXM;
+    SDL_AtomicSet(&_screenshot_stat, SCPE_NXM);
     return;
-    }   
+    }
 if (extension)
     n = extension - _screenshot_filename;
 else {
@@ -2626,12 +3013,12 @@ else {
     }
 strncpy (name, _screenshot_filename, n);
 for (vptr = &vid_first; vptr != NULL; vptr = vptr->next) {
-    if (vid_active > 1)
+    if (SDL_AtomicGet(&vid_active) > 1)
         sprintf (name + n, "%d%s", i++, extension);
     else
         sprintf (name + n, "%s", extension);
-    _screenshot_stat = _vid_screenshot (vptr, name);
-    if (_screenshot_stat != SCPE_OK) {
+    SDL_AtomicSet(&_screenshot_stat, _vid_screenshot (vptr, name));
+    if (SDL_AtomicGet(&_screenshot_stat) != SCPE_OK) {
         free (name);
         return;
         }
@@ -2643,22 +3030,25 @@ t_stat vid_screenshot (const char *filename)
 {
 SDL_Event user_event;
 
-_screenshot_stat = -1;
+SDL_AtomicSet(&_screenshot_stat, -1);
 _screenshot_filename = filename;
 
-user_event.type = SDL_USEREVENT;
+user_event.type = simh_user_event;
 user_event.user.code = EVENT_SCREENSHOT;
 user_event.user.data1 = NULL;
 user_event.user.data2 = NULL;
+
 #if defined (SDL_MAIN_AVAILABLE)
 while (SDL_PushEvent (&user_event) < 0)
     sim_os_ms_sleep (10);
-#else
-vid_screenshot_event ();
-#endif
-while (_screenshot_stat == -1)
+
+while (SDL_AtomicGet(&_screenshot_stat) == -1)
     SDL_Delay (20);
-return _screenshot_stat;
+#else
+vid_screenshot_event (&user_event.user, NULL);
+#endif
+
+return SDL_AtomicGet(&_screenshot_stat);
 }
 
 #include <SDL_audio.h>
@@ -2666,32 +3056,46 @@ return _screenshot_stat;
 
 const int AMPLITUDE = 20000;
 const int SAMPLE_FREQUENCY = 11025;
-static int16 *vid_beep_data;
+static int16 *vid_beep_data = NULL;
 static int vid_beep_offset;
 static int vid_beep_duration;
 static int vid_beep_samples;
+static SDL_cond *vid_beep_cond = NULL;
+static SDL_mutex *vid_beep_mutex = NULL;
+
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+SDL_AudioDeviceID vid_audio_dev = 0;
+#endif
 
 static void vid_audio_callback(void *ctx, Uint8 *stream, int length)
 {
-int i, sum, remnant = ((vid_beep_samples - vid_beep_offset) * sizeof (*vid_beep_data));
+int remnant = ((vid_beep_samples - vid_beep_offset) * sizeof (*vid_beep_data));
+
+UNUSED_ARG(ctx);
 
 if (length > remnant) {
     memset (stream + remnant, 0, length - remnant);
     length = remnant;
     if (remnant == 0) {
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+        if (vid_audio_dev > 0)
+            SDL_PauseAudioDevice(vid_audio_dev, 1);
+#else
         SDL_PauseAudio(1);
+#endif
+
+        /* Signal beep is done. */
+        SDL_CondSignal(vid_beep_cond);
         return;
         }
     }
 memcpy (stream, &vid_beep_data[vid_beep_offset], length);
-for (i=sum=0; i<length; i++)
-    sum += stream[i];
 vid_beep_offset += length / sizeof(*vid_beep_data);
 }
 
 static void vid_beep_setup (int duration_ms, int tone_frequency)
 {
-if (!vid_beep_data) {
+if (vid_beep_data == NULL) {
     int i;
     SDL_AudioSpec desiredSpec;
 
@@ -2703,49 +3107,267 @@ if (!vid_beep_data) {
     desiredSpec.samples = 2048;
     desiredSpec.callback = vid_audio_callback;
 
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+    vid_audio_dev = SDL_OpenAudioDevice(NULL, 0, &desiredSpec, NULL, 0);
+    if (vid_audio_dev == 0) {
+        sim_printf ("Error acquiring audio device, no audio output: %s\n", SDL_GetError());
+        }
+#else
     SDL_OpenAudio(&desiredSpec, NULL);
+#endif
 
     vid_beep_samples = (int)((SAMPLE_FREQUENCY * duration_ms) / 1000.0);
     vid_beep_duration = duration_ms;
     vid_beep_data = (int16 *)malloc (sizeof(*vid_beep_data) * vid_beep_samples);
     for (i=0; i<vid_beep_samples; i++)
         vid_beep_data[i] = (int16)(AMPLITUDE * sin(((double)(i * M_PI * tone_frequency)) / SAMPLE_FREQUENCY));
+
+    vid_beep_cond = SDL_CreateCond();
+    vid_beep_mutex = SDL_CreateMutex();
     }
 }
 
 static void vid_beep_cleanup (void)
 {
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+SDL_CloseAudioDevice(vid_audio_dev);
+#else
 SDL_CloseAudio();
+#endif
+
 free (vid_beep_data);
 vid_beep_data = NULL;
+
+if (vid_beep_cond != NULL) {
+    SDL_DestroyCond(vid_beep_cond);
+    vid_beep_cond = NULL;
+}
+
+if (vid_beep_mutex != NULL) {
+    SDL_DestroyMutex(vid_beep_mutex);
+    vid_beep_mutex = NULL;
+}
+
 SDL_QuitSubSystem (SDL_INIT_AUDIO);
 }
 
-void vid_beep_event (void)
+static void vid_beep_event (SDL_UserEvent *ev, VID_DISPLAY *vptr)
 {
+UNUSED_ARG(ev);
+UNUSED_ARG(vptr);
+
 vid_beep_offset = 0;                /* reset to beginning of sample set */
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+if (vid_audio_dev > 0)
+    SDL_PauseAudioDevice(vid_audio_dev, 0);
+#else
 SDL_PauseAudio (0);                 /* Play sound */
+#endif
 }
 
 void vid_beep (void)
 {
-SDL_Event user_event;
+/* C99 and later initialization style. */
+SDL_Event user_event = {
+    .user.type = simh_user_event,
+    .user.code = EVENT_BEEP,
+    .user.data1 = NULL,
+    .user.data2 = NULL
+};
 
-user_event.type = SDL_USEREVENT;
-user_event.user.code = EVENT_BEEP;
-user_event.user.data1 = NULL;
-user_event.user.data2 = NULL;
+/* Audio output executes in a separate thread, so there's no danger
+ * of deadlocking on the mutex. At worst, vid_beep() will wait until
+ * the previous beep is complete. */
+SDL_LockMutex(vid_beep_mutex);
+
 #if defined (SDL_MAIN_AVAILABLE)
-while (SDL_PushEvent (&user_event) < 0)
-    sim_os_ms_sleep (10);
+SDL_PushEvent(&user_event);
 #else
-vid_beep_event ();
+vid_beep_event(&user_event.user, NULL);
 #endif
-SDL_Delay (vid_beep_duration + 100);/* Wait for sound to finnish */
+
+/* Wait for sound to finish. */
+SDL_CondWait(vid_beep_cond, vid_beep_mutex);
+SDL_UnlockMutex(vid_beep_mutex);
+}
+
+/* Debug pretty printing: */
+
+static void initWindowEventNames()
+{
+    size_t i;
+
+    for (i = 0; i < sizeof(windoweventtypes) / sizeof(windoweventtypes[0]); ++i)
+      windoweventtypes[i] = NULL;
+
+    windoweventtypes[SDL_WINDOWEVENT_NONE] = "NONE";                /**< Never used */
+    windoweventtypes[SDL_WINDOWEVENT_SHOWN] = "SHOWN";              /**< Window has been shown */
+    windoweventtypes[SDL_WINDOWEVENT_HIDDEN] = "HIDDEN";            /**< Window has been hidden */
+    windoweventtypes[SDL_WINDOWEVENT_EXPOSED] = "EXPOSED";          /**< Window has been exposed and should be
+                                                                         redrawn */
+    windoweventtypes[SDL_WINDOWEVENT_MOVED] = "MOVED";              /**< Window has been moved to data1, data2
+                                     */
+    windoweventtypes[SDL_WINDOWEVENT_RESIZED] = "RESIZED";          /**< Window has been resized to data1xdata2 */
+    windoweventtypes[SDL_WINDOWEVENT_SIZE_CHANGED] = "SIZE_CHANGED";/**< The window size has changed, either as a result of an API call or through the system or user changing the window size. */
+    windoweventtypes[SDL_WINDOWEVENT_MINIMIZED] = "MINIMIZED";      /**< Window has been minimized */
+    windoweventtypes[SDL_WINDOWEVENT_MAXIMIZED] = "MAXIMIZED";      /**< Window has been maximized */
+    windoweventtypes[SDL_WINDOWEVENT_RESTORED] = "RESTORED";        /**< Window has been restored to normal size
+                                                                         and position */
+    windoweventtypes[SDL_WINDOWEVENT_ENTER] = "ENTER";              /**< Window has gained mouse focus */
+    windoweventtypes[SDL_WINDOWEVENT_LEAVE] = "LEAVE";              /**< Window has lost mouse focus */
+    windoweventtypes[SDL_WINDOWEVENT_FOCUS_GAINED] = "FOCUS_GAINED";/**< Window has gained keyboard focus */
+    windoweventtypes[SDL_WINDOWEVENT_FOCUS_LOST] = "FOCUS_LOST";    /**< Window has lost keyboard focus */
+    windoweventtypes[SDL_WINDOWEVENT_CLOSE] = "CLOSE";              /**< The window manager requests that the
+                                                                         window be closed */
+    windoweventtypes[SDL_WINDOWEVENT_TAKE_FOCUS] = "TAKE_FOCUS";    /**< Window is being offered a focus (should
+                                                                         SetWindowInputFocus() on itself or a subwindow,
+                                                                         or ignore) */
+}
+
+static const char *getWindowEventName(Uint32 win_event)
+{
+    static char winevname_buf[48] = { '\0', };
+
+    if (win_event < sizeof(windoweventtypes) / sizeof(windoweventtypes[0])) {
+        const char *p = windoweventtypes[win_event];
+        return (p != NULL ? p : "not documented");
+    }
+
+    sprintf(winevname_buf, "SDL window event %u", (Uint32) win_event);
+    return winevname_buf;
+}
+
+static void initEventNames()
+{
+    size_t i;
+
+    for (i = 0; i < sizeof(eventtypes) / sizeof(eventtypes[0]); ++i)
+      eventtypes[i] = NULL;
+
+    eventtypes[SDL_QUIT] = "QUIT";          /**< User-requested quit */
+
+    /* These application events have special meaning on iOS, see README-ios.txt for details */
+    eventtypes[SDL_APP_TERMINATING] = "APP_TERMINATING";   /**< The application is being terminated by the OS
+                                     Called on iOS in applicationWillTerminate()
+                                     Called on Android in onDestroy()
+                                */
+    eventtypes[SDL_APP_LOWMEMORY] = "APP_LOWMEMORY";          /**< The application is low on memory, free memory if possible.
+                                     Called on iOS in applicationDidReceiveMemoryWarning()
+                                     Called on Android in onLowMemory()
+                                */
+    eventtypes[SDL_APP_WILLENTERBACKGROUND] = "APP_WILLENTERBACKGROUND"; /**< The application is about to enter the background
+                                     Called on iOS in applicationWillResignActive()
+                                     Called on Android in onPause()
+                                */
+    eventtypes[SDL_APP_DIDENTERBACKGROUND] = "APP_DIDENTERBACKGROUND"; /**< The application did enter the background and may not get CPU for some time
+                                     Called on iOS in applicationDidEnterBackground()
+                                     Called on Android in onPause()
+                                */
+    eventtypes[SDL_APP_WILLENTERFOREGROUND] = "APP_WILLENTERFOREGROUND"; /**< The application is about to enter the foreground
+                                     Called on iOS in applicationWillEnterForeground()
+                                     Called on Android in onResume()
+                                */
+    eventtypes[SDL_APP_DIDENTERFOREGROUND] = "APP_DIDENTERFOREGROUND"; /**< The application is now interactive
+                                     Called on iOS in applicationDidBecomeActive()
+                                     Called on Android in onResume()
+                                */
+
+    /* Window events */
+    eventtypes[SDL_WINDOWEVENT] = "WINDOWEVENT"; /**< Window state change */
+    eventtypes[SDL_SYSWMEVENT] = "SYSWMEVENT";             /**< System specific event */
+
+    /* Keyboard events */
+    eventtypes[SDL_KEYDOWN] = "KEYDOWN";                            /**< Key pressed */
+    eventtypes[SDL_KEYUP] = "KEYUP";                                /**< Key released */
+    eventtypes[SDL_TEXTEDITING] = "TEXTEDITING";                    /**< Keyboard text editing (composition) */
+    eventtypes[SDL_TEXTINPUT] = "TEXTINPUT";                        /**< Keyboard text input */
+
+    /* Mouse events */
+    eventtypes[SDL_MOUSEMOTION] = "MOUSEMOTION";                    /**< Mouse moved */
+    eventtypes[SDL_MOUSEBUTTONDOWN] = "MOUSEBUTTONDOWN";            /**< Mouse button pressed */
+    eventtypes[SDL_MOUSEBUTTONUP] = "MOUSEBUTTONUP";                /**< Mouse button released */
+    eventtypes[SDL_MOUSEWHEEL] = "MOUSEWHEEL";                      /**< Mouse wheel motion */
+
+    /* Joystick events */
+    eventtypes[SDL_JOYAXISMOTION] = "JOYAXISMOTION";                /**< Joystick axis motion */
+    eventtypes[SDL_JOYBALLMOTION] = "JOYBALLMOTION";                /**< Joystick trackball motion */
+    eventtypes[SDL_JOYHATMOTION] = "JOYHATMOTION";                  /**< Joystick hat position change */
+    eventtypes[SDL_JOYBUTTONDOWN] = "JOYBUTTONDOWN";                /**< Joystick button pressed */
+    eventtypes[SDL_JOYBUTTONUP] = "JOYBUTTONUP";                    /**< Joystick button released */
+    eventtypes[SDL_JOYDEVICEADDED] = "JOYDEVICEADDED";              /**< A new joystick has been inserted into the system */
+    eventtypes[SDL_JOYDEVICEREMOVED] = "JOYDEVICEREMOVED";          /**< An opened joystick has been removed */
+
+    /* Game controller events */
+    eventtypes[SDL_CONTROLLERAXISMOTION] = "CONTROLLERAXISMOTION";          /**< Game controller axis motion */
+    eventtypes[SDL_CONTROLLERBUTTONDOWN] = "CONTROLLERBUTTONDOWN";          /**< Game controller button pressed */
+    eventtypes[SDL_CONTROLLERBUTTONUP] = "CONTROLLERBUTTONUP";              /**< Game controller button released */
+    eventtypes[SDL_CONTROLLERDEVICEADDED] = "CONTROLLERDEVICEADDED";        /**< A new Game controller has been inserted into the system */
+    eventtypes[SDL_CONTROLLERDEVICEREMOVED] = "CONTROLLERDEVICEREMOVED";    /**< An opened Game controller has been removed */
+    eventtypes[SDL_CONTROLLERDEVICEREMAPPED] = "CONTROLLERDEVICEREMAPPED";  /**< The controller mapping was updated */
+
+    /* Touch events */
+    eventtypes[SDL_FINGERDOWN] = "FINGERDOWN";
+    eventtypes[SDL_FINGERUP] = "FINGERUP";
+    eventtypes[SDL_FINGERMOTION] = "FINGERMOTION";
+
+    /* Gesture events */
+    eventtypes[SDL_DOLLARGESTURE] = "DOLLARGESTURE";
+    eventtypes[SDL_DOLLARRECORD] = "DOLLARRECORD";
+    eventtypes[SDL_MULTIGESTURE] = "MULTIGESTURE";
+
+    /* Clipboard events */
+    eventtypes[SDL_CLIPBOARDUPDATE] = "CLIPBOARDUPDATE"; /**< The clipboard changed */
+
+    /* Drag and drop events */
+    eventtypes[SDL_DROPFILE] = "DROPFILE"; /**< The system requests a file open */
+
+#if (SDL_MINOR_VERSION > 0) || (SDL_PATCHLEVEL >= 3)
+    /* Render events */
+    eventtypes[SDL_RENDER_TARGETS_RESET] = "RENDER_TARGETS_RESET"; /**< The render targets have been reset */
+#endif
+
+#if (SDL_MINOR_VERSION > 0) || (SDL_PATCHLEVEL >= 4)
+    /* Render events */
+    eventtypes[SDL_RENDER_DEVICE_RESET] = "RENDER_DEVICE_RESET"; /**< The render device has been reset */
+#endif
+
+    /** Events ::SDL_USEREVENT through ::SDL_LASTEVENT are for your use,
+     *  and should be allocated with SDL_RegisterEvents()
+     */
+    eventtypes[SDL_USEREVENT] = "USEREVENT";
+}
+
+static const char *getEventName(Uint32 ev)
+{
+    static char evname_buf[48] = { '\0', };
+
+    if (ev < sizeof(eventtypes) / sizeof(eventtypes[0])) {
+        const char *p = eventtypes[ev];
+        return (p != NULL ? p : "not documented");
+    }
+
+    sprintf(evname_buf, "SDL event %u", (Uint32) ev);
+    return evname_buf;
+}
+
+static const char *getUserCodeName(Uint32 user_ev_code)
+{
+    static char uevname_buf[48] = { '\0', };
+
+    if (user_ev_code >= EVENT_CLOSE && user_ev_code <= EVENT_SIZE)
+        return userev_names[user_ev_code];
+
+    sprintf(uevname_buf, "SIMH user event %d", user_ev_code);
+    return uevname_buf;
 }
 
 #else /* !(defined(USE_SIM_VIDEO) && defined(HAVE_LIBSDL)) */
 /* Non-implemented versions */
+
+int vid_is_active()
+{
+  return 0;
+}
 
 t_stat vid_open (DEVICE *dptr, const char *title, uint32 width, uint32 height, int flags)
 {

--- a/sim_video.h
+++ b/sim_video.h
@@ -214,7 +214,7 @@ t_stat vid_screenshot (const char *filename);
 t_bool vid_is_fullscreen (void);
 t_stat vid_set_fullscreen (t_bool flag);
 
-extern int vid_active;
+int vid_is_active();                                    /* Get vid_active flag */
 void vid_set_cursor_position (int32 x, int32 y);        /* cursor position (set by calling code) */
 void vid_set_window_size (VID_DISPLAY *vptr, int32 x, int32 y);            /* window size (set by calling code) */
 
@@ -249,6 +249,7 @@ extern int (*vid_display_kb_event_process)(SIM_KEY_EVENT *kev);
 #define SIM_VID_DBG_CURSOR  0x20000000
 #define SIM_VID_DBG_KEY     0x40000000
 #define SIM_VID_DBG_VIDEO   0x80000000
+#define SIM_VID_DBG_ALL     (SIM_VID_DBG_VIDEO|SIM_VID_DBG_KEY|SIM_VID_DBG_MOUSE|SIM_VID_DBG_CURSOR)
 
 #ifdef  __cplusplus
 }


### PR DESCRIPTION
Open latency: Encountered in Windows Subsystem for Linux (WSL). WSL graphics initialization takes more than 20x100ms (2 seconds).  It's a non-deterministic delay accrued across OS thread scheduling, WSL's window emulation system and the underlying video event processing loop's execution.

Accomodate the non-determinism via a condition variable and associated mutex to signal EVENT_OPEN's completion.

  - The EVENT_OPEN-generating thread initializes a startup structure that contains the condition variable and mutex, which is passed to the EVENT_OPEN event. The thread then waits for the condition to signal via SDL_CondWait().

  - The EVENT_OPEN event processing queues EVENT_OPENCOMPLETE before returning.

  - EVENT_OPENCOMPLETE signals the condition variable and the SDL_CondWait()-ing thread resumes.

Unrecognized events: PDP-11's VT demo mode ("lunar lander") generates messages when emitting the bell (beep).  These messages are attributed to a SDL issue (presumably prior to SDL2 2.0.6.)

EVENT_REDRAW optimization generates these spurious messages via the vid_get_event_window() function, which reports an unrecognized SDL event if it cannot associate a VID_DISPLAY with an event's window identifier. Not all SIMH video events require a non-NULL VID_DISPLAY pointer.

  - Separate unrecognized event reporting from vid_get_event_window(). If a function expects a valid VID_DISPLAY ptr and gets NULL, then it should report the error via reportUnrecognizedEvent().

  - vid_video_events(): Simplified -- process one event at a time. A function dispatch table drives SIMH video event processing.

  - Separate redraws from SIMH events so that SDL_PeepEvents() filters ONLY on redraw events. Simplifies coalescing duplicate redraw events for the same window.

  - Redraw frame rate: Coalesce redraw requests if they arrive faster than human perception (30 fps) into a deferred redraw event queued by a SDL_AddTimer() callback. Skip window refresh requests if a deferred redraw request is pending.

Functional changes:

- vid_active: Changed to SDL_atomic_t (from int) to ensure correct cross-thread writes. Actually encountered on AARCH64.

- vid_is_active(): vid_active accessor function.  Updated references in VAX/vax4xx_{va,vc,ve}.c, VAX/vax_{va,vc}.c.

- VID_DISPLAY::vid_ready: Changed to SDL_atomic_t (from t_bool) to ensure correct cross-thread writes. Actually encountered on AARCH64.

- sim_video_system_init(): Consolidated SDL2 initialiation function. Allocates the simh_user_event and simh_redraw_event identifiers, initializes the event and window event debug strings, calls SDL_Init().

- Use the newer audio API when SDL version >= 2.0.6, as the SDL documentation strongly suggests and future-proof the code.

- vid_beep_cond, vid_beep_mutex: SIMH is supposed to wait until the entirety of a audio bell plays out. Instead of using SDL_Delay(), use condition variable and mutex to wait exactly the duration needed.

Cosmetic changes:

- Window event, event and user event debugging functions: Initialization code moved out of vid_video_events(). reportUnrecognizedEvent() reports developer-friendly output.

- simh_user_event, simh_redraw_event: SDL_RegisterEvents()-generated event identifiers for SIMH events, vice using the SDL_USEREVENT constant. SDL_RegisterEvents() is the preferred method for defining application-specific events (RTFM SDL_PushEvent().)