### PR TITLE
IBM 1130 Fix address computation overflow.

### DIFF
--- a/Ibm1130/ibm1130_cpu.c
+++ b/Ibm1130/ibm1130_cpu.c
@@ -653,7 +653,7 @@ t_stat sim_instr (void)
 
             eaddr = word2;                  /* assume standard addressing & compute effective address */
             if (TAG)                        /* if indexed */
-                eaddr += ReadIndex(TAG);    /* add index register value */
+		eaddr = (eaddr + ReadIndex(TAG)) & 0xFFFF;	/* add index register value */
             if (INDIR)                      /* if indirect addressing */
                 eaddr = ReadW(eaddr);       /* pick up referenced address */
             


### PR DESCRIPTION
In sim_instr(), the effective address is computed; for the case of TAG (index register addressing), the contents of
the specified index register is added to the effective address, but the result is not masked to 16 bits as per the
hardware functionality. 

Adding a a 16 bit mask operation fixes the issue.