### PR TITLE
macOS-12 CI/CD failure fix, periodic CMake regenerate

### DIFF
--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -3,7 +3,7 @@
 install_osx() {
     brew update
     brew install pkg-config pcre libpng libedit sdl2 freetype2 sdl2_ttf \
-        vde cmake gnu-getopt coreutils
+        vde cmake gnu-getopt coreutils zlib
 }
 
 install_arch_linux() {

--- a/AltairZ80/CMakeLists.txt
+++ b/AltairZ80/CMakeLists.txt
@@ -18,6 +18,7 @@ add_simulator(altairz80
     SOURCES
         altairz80_cpu.c
         altairz80_cpu_nommu.c
+        s100_tuart.c
         s100_dazzler.c
         s100_jair.c
         sol20.c
@@ -62,7 +63,6 @@ add_simulator(altairz80
         s100_scp300f.c
         s100_tarbell.c
         s100_tdd.c
-	s100_tuart.c
         wd179x.c
         s100_hdc1001.c
         s100_if3.c

--- a/Ibm1130/CMakeLists.txt
+++ b/Ibm1130/CMakeLists.txt
@@ -31,11 +31,16 @@ add_simulator(ibm1130
         ibm1130_t2741.c
     INCLUDES
         ${CMAKE_CURRENT_SOURCE_DIR}
+    TEST_ARGS "-g"
     LABEL Ibm1130
     PKG_FAMILY ibm_family
     TEST ibm1130)
 
 if (WIN32)
+    ## Add GUI support, compile in resources:
     target_compile_definitions(ibm1130 PRIVATE GUI_SUPPORT)
-    ## missing source in IBM1130?    ## target_sources(ibm1130 PRIVATE ibm1130.c)
+    target_sources(ibm1130 PRIVATE ibm1130.rc)
 endif()
+
+# IBM 1130 utilities:
+# add_subdirectory(utils)

--- a/PDP10/CMakeLists.txt
+++ b/PDP10/CMakeLists.txt
@@ -114,6 +114,7 @@ add_simulator(pdp10-ka
     FEATURE_INT64
     FEATURE_VIDEO
     FEATURE_DISPLAY
+    USES_AIO
     LABEL PDP10
     PKG_FAMILY pdp10_family
     TEST ka10)
@@ -161,6 +162,7 @@ add_simulator(pdp10-ki
     FEATURE_INT64
     FEATURE_VIDEO
     FEATURE_DISPLAY
+    USES_AIO
     LABEL PDP10
     PKG_FAMILY pdp10_family
     TEST ki10)
@@ -193,6 +195,7 @@ add_simulator(pdp10-kl
     DEFINES
         KL=1
     FEATURE_INT64
+    USES_AIO
     LABEL PDP10
     PKG_FAMILY pdp10_family
     TEST kl10)
@@ -220,6 +223,7 @@ add_simulator(pdp10-ks
     DEFINES
         KS=1
     FEATURE_INT64
+    USES_AIO
     LABEL PDP10
     PKG_FAMILY pdp10_family
     TEST ks10)

--- a/VAX/CMakeLists.txt
+++ b/VAX/CMakeLists.txt
@@ -566,12 +566,12 @@ add_simulator(vax8200
         vax_sys.c
         vax_syscm.c
         vax_watch.c
-        vax_uw.c
         vax820_stddev.c
         vax820_bi.c
         vax820_mem.c
         vax820_uba.c
         vax820_ka.c
+        vax_uw.c
         vax820_syslist.c
         ${PDP11D}/pdp11_rl.c
         ${PDP11D}/pdp11_rq.c
@@ -615,12 +615,12 @@ add_simulator(vax8600
         vax_mmu.c
         vax_sys.c
         vax_syscm.c
-        vax_uw.c
         vax860_stddev.c
         vax860_sbia.c
         vax860_abus.c
         vax780_uba.c
         vax7x0_mba.c
+        vax_uw.c
         vax860_syslist.c
         ${PDP11D}/pdp11_rl.c
         ${PDP11D}/pdp11_rq.c

--- a/makefile
+++ b/makefile
@@ -2074,7 +2074,7 @@ KA10 = ${KA10D}/kx10_cpu.c ${KA10D}/kx10_sys.c ${KA10D}/kx10_df.c \
 	${KA10D}/ka10_ai.c ${KA10D}/ka10_iii.c ${KA10D}/kx10_disk.c \
 	${KA10D}/ka10_pclk.c ${KA10D}/ka10_tv.c ${KA10D}/ka10_dd.c \
     ${KA10D}/kx10_ddc.c ${DISPLAYL} ${DISPLAY340} ${DISPLAYIII}
-KA10_OPT = -DKA=1 -DUSE_INT64 -I ${KA10D} -DUSE_SIM_CARD ${NETWORK_OPT} ${DISPLAY_OPT} ${KA10_DISPLAY_OPT}
+KA10_OPT = -DKA=1 -DUSE_INT64 -I ${KA10D} -DUSE_SIM_CARD ${NETWORK_OPT} ${DISPLAY_OPT} ${KA10_DISPLAY_OPT} ${AIO_CCDEFS}
 ifneq (${PANDA_LIGHTS},)
 # ONLY for Panda display.
 KA10_OPT += -DPANDA_LIGHTS
@@ -2094,7 +2094,7 @@ KI10 = ${KI10D}/kx10_cpu.c ${KI10D}/kx10_sys.c ${KI10D}/kx10_df.c \
 	${KI10D}/kx10_cp.c ${KI10D}/kx10_tu.c ${KI10D}/kx10_rs.c \
 	${KI10D}/kx10_imp.c ${KI10D}/kx10_dpy.c ${KI10D}/kx10_disk.c \
     ${KI10D}/kx10_ddc.c ${KI10D}/kx10_tym.c ${DISPLAYL} ${DISPLAY340}
-KI10_OPT = -DKI=1 -DUSE_INT64 -I ${KI10D} -DUSE_SIM_CARD ${NETWORK_OPT} ${DISPLAY_OPT} ${KI10_DISPLAY_OPT}
+KI10_OPT = -DKI=1 -DUSE_INT64 -I ${KI10D} -DUSE_SIM_CARD ${NETWORK_OPT} ${DISPLAY_OPT} ${KI10_DISPLAY_OPT} ${AIO_CCDEFS}
 ifneq (${PANDA_LIGHTS},)
 # ONLY for Panda display.
 KI10_OPT += -DPANDA_LIGHTS
@@ -2110,7 +2110,7 @@ KL10 =  ${KL10D}/kx10_cpu.c ${KL10D}/kx10_sys.c ${KL10D}/kx10_df.c \
     ${KL10D}/kx10_rp.c ${KL10D}/kx10_tu.c ${KL10D}/kx10_rs.c \
     ${KL10D}/kx10_imp.c ${KL10D}/kl10_fe.c ${KL10D}/ka10_pd.c \
     ${KL10D}/ka10_ch10.c ${KL10D}/kl10_nia.c ${KL10D}/kx10_disk.c
-KL10_OPT = -DKL=1 -DUSE_INT64 -I $(KL10D) -DUSE_SIM_CARD ${NETWORK_OPT} 
+KL10_OPT = -DKL=1 -DUSE_INT64 -I $(KL10D) -DUSE_SIM_CARD ${NETWORK_OPT}  ${AIO_CCDEFS}
 
 KS10D = ${SIMHD}/PDP10
 KS10 = ${KS10D}/kx10_cpu.c ${KS10D}/kx10_sys.c ${KS10D}/kx10_disk.c \
@@ -2118,7 +2118,7 @@ KS10 = ${KS10D}/kx10_cpu.c ${KS10D}/kx10_sys.c ${KS10D}/kx10_disk.c \
 	${KS10D}/kx10_rp.c ${KS10D}/kx10_tu.c ${KS10D}/ks10_dz.c \
 	${KS10D}/ks10_tcu.c ${KS10D}/ks10_lp.c ${KS10D}/ks10_ch11.c \
 	${KS10D}/ks10_kmc.c ${KS10D}/ks10_dup.c ${KS10D}/kx10_imp.c
-KS10_OPT = -DKS=1 -DUSE_INT64 -I $(KS10D) -I $(PDP11D) ${NETWORK_OPT}
+KS10_OPT = -DKS=1 -DUSE_INT64 -I $(KS10D) -I $(PDP11D) ${NETWORK_OPT} ${AIO_CCDEFS}
 
 ATT3B2D = ${SIMHD}/3B2
 ATT3B2M400 = ${ATT3B2D}/3b2_cpu.c ${ATT3B2D}/3b2_sys.c \

--- a/makefile
+++ b/makefile
@@ -675,13 +675,13 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
       OS_CCDEFS += -DHAVE_LIBPNG
       OS_LDFLAGS += -lpng
       $(info using libpng: $(call find_lib,png) $(call find_include,png))
-      ifneq (,$(call find_include,zlib))
-        ifneq (,$(call find_lib,z))
-          OS_CCDEFS += -DHAVE_ZLIB
-          OS_LDFLAGS += -lz
-          $(info using zlib: $(call find_lib,z) $(call find_include,zlib))
-        endif
-      endif
+    endif
+  endif
+  ifneq (,$(call find_include,zlib))
+    ifneq (,$(call find_lib,z))
+      OS_CCDEFS += -DHAVE_ZLIB
+      OS_LDFLAGS += -lz
+      $(info using zlib: $(call find_lib,z) $(call find_include,zlib))
     endif
   endif
   ifneq (,$(call find_include,glob))


### PR DESCRIPTION
- zlib now needs to be an explicit HomeBrew dependency. Previously, Apple distributed zlib as part of macOS. That is no longer the case.

- CMake: Periodic `generate.py` to update simulator `CMakeLists.txt` build files.

- PDP-10: Not entirely clear to me how/when `AIO_CCFLAGS` went missing (which causes `generate.py` to add `USES_AIO` to the CMake `add_simulator` arguments. Without AIO, the PDP-10 simulator users get a warning message with respect to AIO and networking.