### PR TITLE
Revert "Compile fix: replaced Uint8 by uint8."

### DIFF
--- a/display/sim_ws.c
+++ b/display/sim_ws.c
@@ -77,8 +77,8 @@ static uint32 ncolors = 0, size_colors = 0;
 static uint32 *surface = NULL;
 static uint32 ws_palette[2];                            /* Monochrome palette */
 typedef struct cursor {
-    uint8 *data;
-    uint8 *mask;
+    Uint8 *data;
+    Uint8 *mask;
     int width;
     int height;
     int hot_x;
@@ -310,8 +310,8 @@ static const char *cross[] = {
 static CURSOR *ws_create_cursor(const char *image[])
 {
 int byte, bit, row, col;
-uint8 *data = NULL;
-uint8 *mask = NULL;
+Uint8 *data = NULL;
+Uint8 *mask = NULL;
 char black, white, transparent;
 CURSOR *result = NULL;
 int width, height, colors, cpp;
@@ -325,8 +325,8 @@ if ((cpp != 1) || (0 != width%8) || (colors != 3))
 black = image[1][0];
 white = image[2][0];
 transparent = image[3][0];
-data = (uint8 *)calloc (1, (width / 8) * height);
-mask = (uint8 *)calloc (1, (width / 8) * height);
+data = (Uint8 *)calloc (1, (width / 8) * height);
+mask = (Uint8 *)calloc (1, (width / 8) * height);
 if (!data || !mask) {
     free (data);
     free (mask);


### PR DESCRIPTION
The "error" that the original change "fixed" was actually in the cmake build system and not in the sim_ws.c code.

The Uint8 type is specific to SDL2 APIs.

This is now rebased on the cmake fixes so the CI/CD builds should run cleanly.