### PR TITLE
Allow msys2 clang64 to compile with cmake

### DIFF
--- a/cmake/pthreads-dep.cmake
+++ b/cmake/pthreads-dep.cmake
@@ -12,7 +12,7 @@ set(AIO_FLAGS)
 if (WITH_ASYNC)
     include(ExternalProject)
 
-    if (MSVC OR (WIN32 AND CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+    if (MSVC OR (WIN32 AND CMAKE_C_COMPILER_ID MATCHES ".*Clang.*with MSVC-like command-line.*"))
         # Pthreads4w: pthreads for windows.
         if (USING_VCPKG)
             find_package(PThreads4W REQUIRED)


### PR DESCRIPTION
Currently when building with msys2 in a clang64 environment, cmake tries to use pthreads4w and fails. This restricts the compiler check to clang-cl only so mingw64 clang environments aren't affected.