### PR TITLE
VAX: Mask QBus addresses to 22 bits

### DIFF
--- a/VAX/vax630_io.c
+++ b/VAX/vax630_io.c
@@ -619,6 +619,7 @@ int32 Map_ReadB (uint32 ba, int32 bc, uint8 *buf)
 int32 i;
 uint32 ma, dat;
 
+ba &= 0x003FFFFF;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i++, buf++) {              /* by bytes */
         if ((ma & VA_M_OFF) == 0) {                     /* need map? */
@@ -651,6 +652,7 @@ int32 Map_ReadW (uint32 ba, int32 bc, uint16 *buf)
 int32 i;
 uint32 ma,dat;
 
+ba &= 0x003FFFFF;
 ba = ba & ~01;
 bc = bc & ~01;
 if ((ba | bc) & 03) {                                   /* check alignment */
@@ -683,6 +685,7 @@ int32 Map_WriteB (uint32 ba, int32 bc, const uint8 *buf)
 int32 i;
 uint32 ma, dat;
 
+ba &= 0x003FFFFF;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i++, buf++) {              /* by bytes */
         if ((ma & VA_M_OFF) == 0) {                     /* need map? */
@@ -715,6 +718,7 @@ int32 Map_WriteW (uint32 ba, int32 bc, const uint16 *buf)
 int32 i;
 uint32 ma, dat;
 
+ba &= 0x003FFFFF;
 ba = ba & ~01;
 bc = bc & ~01;
 if ((ba | bc) & 03) {                                   /* check alignment */

--- a/VAX/vax630_io.c
+++ b/VAX/vax630_io.c
@@ -619,7 +619,7 @@ int32 Map_ReadB (uint32 ba, int32 bc, uint8 *buf)
 int32 i;
 uint32 ma, dat;
 
-ba &= 0x003FFFFF;
+ba = ba & 0x00FFFFFF;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i++, buf++) {              /* by bytes */
         if ((ma & VA_M_OFF) == 0) {                     /* need map? */
@@ -652,8 +652,7 @@ int32 Map_ReadW (uint32 ba, int32 bc, uint16 *buf)
 int32 i;
 uint32 ma,dat;
 
-ba &= 0x003FFFFF;
-ba = ba & ~01;
+ba = ba & 0x00FFFFFE;
 bc = bc & ~01;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i = i + 2, buf++) {        /* by words */
@@ -685,7 +684,7 @@ int32 Map_WriteB (uint32 ba, int32 bc, const uint8 *buf)
 int32 i;
 uint32 ma, dat;
 
-ba &= 0x003FFFFF;
+ba = ba & 0x00FFFFFF;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i++, buf++) {              /* by bytes */
         if ((ma & VA_M_OFF) == 0) {                     /* need map? */
@@ -718,8 +717,7 @@ int32 Map_WriteW (uint32 ba, int32 bc, const uint16 *buf)
 int32 i;
 uint32 ma, dat;
 
-ba &= 0x003FFFFF;
-ba = ba & ~01;
+ba = ba & 0x00FFFFFE;
 bc = bc & ~01;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i = i + 2, buf++) {        /* by words */

--- a/VAX/vax630_io.c
+++ b/VAX/vax630_io.c
@@ -619,7 +619,7 @@ int32 Map_ReadB (uint32 ba, int32 bc, uint8 *buf)
 int32 i;
 uint32 ma, dat;
 
-ba = ba & 0x00FFFFFF;
+ba = ba & QBMAMASK;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i++, buf++) {              /* by bytes */
         if ((ma & VA_M_OFF) == 0) {                     /* need map? */
@@ -652,7 +652,7 @@ int32 Map_ReadW (uint32 ba, int32 bc, uint16 *buf)
 int32 i;
 uint32 ma,dat;
 
-ba = ba & 0x00FFFFFE;
+ba = ba & QBMAMASK & ~01;
 bc = bc & ~01;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i = i + 2, buf++) {        /* by words */
@@ -684,7 +684,7 @@ int32 Map_WriteB (uint32 ba, int32 bc, const uint8 *buf)
 int32 i;
 uint32 ma, dat;
 
-ba = ba & 0x00FFFFFF;
+ba = ba & QBMAMASK;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i++, buf++) {              /* by bytes */
         if ((ma & VA_M_OFF) == 0) {                     /* need map? */
@@ -717,7 +717,7 @@ int32 Map_WriteW (uint32 ba, int32 bc, const uint16 *buf)
 int32 i;
 uint32 ma, dat;
 
-ba = ba & 0x00FFFFFE;
+ba = ba & QBMAMASK & ~01;
 bc = bc & ~01;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i = i + 2, buf++) {        /* by words */

--- a/VAX/vax_io.c
+++ b/VAX/vax_io.c
@@ -106,6 +106,12 @@
 
 #define QB_VEC_MASK     0x1FC                           /* Interrupt Vector value mask */
 
+/* Qbus memory space */
+
+#define QBMAWIDTH       22                              /* Qmem addr width */
+#define QBMSIZE         (1u << QBMAWIDTH)               /* Qmem length */
+#define QBMAMASK        (QBMSIZE - 1)                   /* Qmem addr mask */
+
 int32 int_req[IPL_HLVL] = { 0 };                        /* intr, IPL 14-17 */
 int32 int_vec_set[IPL_HLVL][32] = { 0 };                /* bits to set in vector */
 int32 cq_scr = 0;                                       /* SCR */
@@ -765,6 +771,7 @@ int32 Map_ReadB (uint32 ba, int32 bc, uint8 *buf)
 int32 i;
 uint32 ma, dat;
 
+ba = ba & QBMAMASK;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i++, buf++) {              /* by bytes */
         if ((ma & VA_M_OFF) == 0) {                     /* need map? */
@@ -797,7 +804,7 @@ int32 Map_ReadW (uint32 ba, int32 bc, uint16 *buf)
 int32 i;
 uint32 ma,dat;
 
-ba = ba & ~01;
+ba = ba & QBMAMASK & ~01;
 bc = bc & ~01;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i = i + 2, buf++) {        /* by words */
@@ -829,6 +836,7 @@ int32 Map_WriteB (uint32 ba, int32 bc, const uint8 *buf)
 int32 i;
 uint32 ma, dat;
 
+ba = ba & QBMAMASK;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i++, buf++) {              /* by bytes */
         if ((ma & VA_M_OFF) == 0) {                     /* need map? */
@@ -861,7 +869,7 @@ int32 Map_WriteW (uint32 ba, int32 bc, const uint16 *buf)
 int32 i;
 uint32 ma, dat;
 
-ba = ba & ~01;
+ba = ba & QBMAMASK & ~01;
 bc = bc & ~01;
 if ((ba | bc) & 03) {                                   /* check alignment */
     for (i = ma = 0; i < bc; i = i + 2, buf++) {        /* by words */


### PR DESCRIPTION
Fixes issue #409 
Ultrix-32M v1.2 has a hardcoded bdp value (buffered data path) or'd into the memory address sent to an MSCP device. The memory address is subsequently used as a destination for the disk read, but since it is outside of the memory range, the device reports an I/O error causing the OS to fail.

This patch masks all QBus transfer addresses to 22 bits which allows Ultrix-32M v1.2 to install and run correctly.
