### PR TITLE
NET: Don't unconditionally turn on Ethernet debugging

### DIFF
--- a/3B2/3b2_ni.c
+++ b/3B2/3b2_ni.c
@@ -939,7 +939,7 @@ t_stat ni_attach(UNIT *uptr, CONST char *cptr)
         return SCPE_MEM;
     }
 
-    status = eth_open(ni.eth, cptr, &ni_dev, DBG_ETH);
+    status = eth_open(ni.eth, cptr, &ni_dev, ni_dev.dctrl & DBG_ETH);
     if (status != SCPE_OK) {
         sim_debug(DBG_ERR, &ni_dev, "ni_attach failure: open\n");
         free(tptr);

--- a/PDP10/kx10_imp.c
+++ b/PDP10/kx10_imp.c
@@ -3155,7 +3155,7 @@ t_stat imp_attach(UNIT* uptr, CONST char* cptr)
     strcpy(tptr, cptr);
 
     memset(&imp_data.ReadQ, 0, sizeof(ETH_QUE));
-    status = eth_open(&imp_data.etherface, cptr, &imp_dev, DEBUG_ETHER);
+    status = eth_open(&imp_data.etherface, cptr, &imp_dev, imp_dev.dctrl & DEBUG_ETHER);
     if (status != SCPE_OK) {
       free(tptr);
       return status;

--- a/PDP11/pdp11_xq.c
+++ b/PDP11/pdp11_xq.c
@@ -2886,7 +2886,7 @@ t_stat xq_attach(UNIT* uptr, CONST char* cptr)
     return SCPE_MEM;
     }
 
-  status = eth_open(xq->var->etherface, cptr, xq->dev, DBG_ETH);
+  status = eth_open(xq->var->etherface, cptr, xq->dev, xq->dev->dctrl & DBG_ETH);
   if (status != SCPE_OK) {
     free(tptr);
     free(xq->var->etherface);

--- a/PDP11/pdp11_xu.c
+++ b/PDP11/pdp11_xu.c
@@ -1767,7 +1767,7 @@ t_stat xu_attach(UNIT* uptr, CONST char* cptr)
     return SCPE_MEM;
     }
 
-  status = eth_open(xu->var->etherface, cptr, xu->dev, DBG_ETH);
+  status = eth_open(xu->var->etherface, cptr, xu->dev, xu->dev->dctrl & DBG_ETH);
   if (status != SCPE_OK) {
     free(tptr);
     free(xu->var->etherface);

--- a/SEL32/sel32_ec.c
+++ b/SEL32/sel32_ec.c
@@ -1868,7 +1868,7 @@ t_stat ec_attach(UNIT* uptr, CONST char* cptr)
 
     memcpy(&ec_data.macs[0], &ec_data.mac, sizeof (ETH_MAC));
     memcpy(&ec_data.macs[1], &broadcast_ethaddr, sizeof (ETH_MAC));
-    status = eth_open(&ec_data.etherface, cptr, &ec_dev, DEBUG_ETHER);
+    status = eth_open(&ec_data.etherface, cptr, &ec_dev, ec_dev.dctrl & DEBUG_ETHER);
     if (status != SCPE_OK) {
         free(tptr);
         return status;

--- a/VAX/vax_xs.c
+++ b/VAX/vax_xs.c
@@ -740,7 +740,7 @@ if (!xs->var->etherface) {
     return SCPE_MEM;
     }
 
-status = eth_open(xs->var->etherface, cptr, xs->dev, DBG_ETH);
+status = eth_open(xs->var->etherface, cptr, xs->dev, xs->dev->dctrl & DBG_ETH);
 if (status != SCPE_OK) {
     free(tptr);
     free(xs->var->etherface);


### PR DESCRIPTION
Make Ethernet debugging (DBG_ETH, DEBUG_ETHER) conditional on the simulator's debugging bits. User must explicitly enable ETH debugging, whereas the default polluted the debug output unconditionaly.