### PR TITLE
CMake: Add sanitizer support

### DIFF
--- a/cmake/FindASan.cmake
+++ b/cmake/FindASan.cmake
@@ -1,0 +1,66 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_ADDRESS "Enable AddressSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=address"
+
+    # Clang 3.2+ use this version. The no-omit-frame-pointer option is optional.
+    "-g -fsanitize=address -fsanitize-address-use-after-return=always -fsanitize-address-use-after-scope"
+    "-g -fsanitize=address -fsanitize-address-use-after-return=always"
+    "-g -fsanitize=address -fsanitize-address-use-after-scope"
+    "-g -fsanitize=address"
+    ## "-g -fsanitize=address -fno-omit-frame-pointer -fPIE"
+    ## "-g -fsanitize=address -fno-omit-frame-pointer"
+
+    # Older deprecated flag for ASan
+    "-g -faddress-sanitizer"
+)
+
+
+if (SANITIZE_ADDRESS AND (SANITIZE_THREAD OR SANITIZE_MEMORY))
+    message(FATAL_ERROR "AddressSanitizer is not compatible with "
+        "ThreadSanitizer or MemorySanitizer.")
+endif ()
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_ADDRESS)
+    sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "AddressSanitizer"
+        "ASan")
+
+    find_program(ASan_WRAPPER "asan-wrapper" PATHS ${CMAKE_MODULE_PATH})
+	mark_as_advanced(ASan_WRAPPER)
+endif ()
+
+function (add_sanitize_address TARGET)
+    if (NOT SANITIZE_ADDRESS)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "AddressSanitizer" "ASan")
+endfunction ()

--- a/cmake/FindMSan.cmake
+++ b/cmake/FindMSan.cmake
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_MEMORY "Enable MemorySanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=memory"
+    # GNU/Clang
+    "-g -fsanitize=memory -fno-omit-frame-pointer -fPIE"
+    "-g -fsanitize=memory -fno-omit-frame-pointer"
+    "-g -fsanitize=memory"
+)
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_MEMORY)
+    if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        message(WARNING "MemorySanitizer disabled for target ${TARGET} because "
+            "MemorySanitizer is supported for Linux systems only.")
+        set(SANITIZE_MEMORY Off CACHE BOOL
+            "Enable MemorySanitizer for sanitized targets." FORCE)
+    elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+        message(WARNING "MemorySanitizer disabled for target ${TARGET} because "
+            "MemorySanitizer is supported for 64bit systems only.")
+        set(SANITIZE_MEMORY Off CACHE BOOL
+            "Enable MemorySanitizer for sanitized targets." FORCE)
+    else ()
+        sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "MemorySanitizer"
+            "MSan")
+    endif ()
+endif ()
+
+function (add_sanitize_memory TARGET)
+    if (NOT SANITIZE_MEMORY)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "MemorySanitizer" "MSan")
+endfunction ()

--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -1,0 +1,91 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# If any of the used compiler is a GNU compiler, add a second option to static
+# link against the sanitizers.
+option(SANITIZE_LINK_STATIC "Try to link static against sanitizers." Off)
+
+# Highlight this module has been loaded.
+set(Sanitizers_FOUND TRUE)
+
+set(FIND_QUIETLY_FLAG "")
+if (DEFINED Sanitizers_FIND_QUIETLY)
+    set(FIND_QUIETLY_FLAG "QUIET")
+endif ()
+
+find_package(ASan ${FIND_QUIETLY_FLAG})
+find_package(TSan ${FIND_QUIETLY_FLAG})
+find_package(MSan ${FIND_QUIETLY_FLAG})
+find_package(UBSan ${FIND_QUIETLY_FLAG})
+
+function(sanitizer_add_blacklist_file FILE)
+    if(NOT IS_ABSOLUTE ${FILE})
+        set(FILE "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}")
+    endif()
+    get_filename_component(FILE "${FILE}" REALPATH)
+
+    sanitizer_check_compiler_flags("-fsanitize-blacklist=${FILE}"
+        "SanitizerBlacklist" "SanBlist")
+endfunction()
+
+function(add_sanitizers)
+    # If no sanitizer is enabled, return immediately.
+    if (NOT (SANITIZE_ADDRESS OR SANITIZE_MEMORY OR SANITIZE_THREAD OR
+        SANITIZE_UNDEFINED))
+        return()
+    endif ()
+
+    foreach (TARGET ${ARGV})
+        # Check if this target will be compiled by exactly one compiler. Other-
+        # wise sanitizers can't be used and a warning should be printed once.
+        get_target_property(TARGET_TYPE ${TARGET} TYPE)
+        if (TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
+            message(WARNING "Can't use any sanitizers for target ${TARGET}, "
+                    "because it is an interface library and cannot be "
+                    "compiled directly.")
+            return()
+        endif ()
+        sanitizer_target_compilers(${TARGET} TARGET_COMPILER)
+        list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+        if (NUM_COMPILERS GREATER 1)
+            message(WARNING "Can't use any sanitizers for target ${TARGET}, "
+                    "because it will be compiled by incompatible compilers. "
+                    "Target will be compiled without sanitizers.")
+            return()
+
+        elseif (NUM_COMPILERS EQUAL 0)
+            # If the target is compiled by no known compiler, give a warning.
+            message(WARNING "Sanitizers for target ${TARGET} may not be"
+                    " usable, because it uses no or an unknown compiler. "
+                    "This is a false warning for targets using only "
+                    "object lib(s) as input.")
+        endif ()
+
+        # Add sanitizers for target.
+        add_sanitize_address(${TARGET})
+        add_sanitize_thread(${TARGET})
+        add_sanitize_memory(${TARGET})
+        add_sanitize_undefined(${TARGET})
+    endforeach ()
+endfunction(add_sanitizers)

--- a/cmake/FindTSan.cmake
+++ b/cmake/FindTSan.cmake
@@ -1,0 +1,70 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_THREAD "Enable ThreadSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=thread"
+    # GNU/Clang
+    "-g -fsanitize=thread -fno-omit-frame-pointer -fPIE"
+    "-g -fsanitize=thread -fno-omit-frame-pointer"
+    "-g -fsanitize=thread"
+)
+
+
+# ThreadSanitizer is not compatible with MemorySanitizer.
+if (SANITIZE_THREAD AND SANITIZE_MEMORY)
+    message(FATAL_ERROR "ThreadSanitizer is not compatible with "
+        "MemorySanitizer.")
+endif ()
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_THREAD)
+  if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND
+      NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+        message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
+          "ThreadSanitizer is supported for Linux systems and macOS only.")
+        set(SANITIZE_THREAD Off CACHE BOOL
+            "Enable ThreadSanitizer for sanitized targets." FORCE)
+    elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+        message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
+            "ThreadSanitizer is supported for 64bit systems only.")
+        set(SANITIZE_THREAD Off CACHE BOOL
+            "Enable ThreadSanitizer for sanitized targets." FORCE)
+    else ()
+        sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "ThreadSanitizer"
+            "TSan")
+    endif ()
+endif ()
+
+function (add_sanitize_thread TARGET)
+    if (NOT SANITIZE_THREAD)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "ThreadSanitizer" "TSan")
+endfunction ()

--- a/cmake/FindUBSan.cmake
+++ b/cmake/FindUBSan.cmake
@@ -1,0 +1,50 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_UNDEFINED
+    "Enable UndefinedBehaviorSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=undefined"
+    # GNU/Clang
+    "-g -fsanitize=undefined -fno-omit-frame-pointer -fPIE"
+    "-g -fsanitize=undefined"
+)
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_UNDEFINED)
+    sanitizer_check_compiler_flags("${FLAG_CANDIDATES}"
+        "UndefinedBehaviorSanitizer" "UBSan")
+endif ()
+
+function (add_sanitize_undefined TARGET)
+    if (NOT SANITIZE_UNDEFINED)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "UndefinedBehaviorSanitizer" "UBSan")
+endfunction ()

--- a/cmake/Sanitizers-README.md
+++ b/cmake/Sanitizers-README.md
@@ -1,0 +1,73 @@
+# sanitizers-cmake
+
+ [![](https://img.shields.io/github/issues-raw/arsenm/sanitizers-cmake.svg?style=flat-square)](https://github.com/arsenm/sanitizers-cmake/issues)
+[![MIT](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
+
+CMake module to enable sanitizers for binary targets.
+
+
+## Include into your project
+
+To use [FindSanitizers.cmake](cmake/FindSanitizers.cmake), simply add this repository as git submodule into your own repository
+```Shell
+mkdir externals
+git submodule add git@github.com:arsenm/sanitizers-cmake.git externals/sanitizers-cmake
+```
+and adding ```externals/sanitizers-cmake/cmake``` to your ```CMAKE_MODULE_PATH```
+```CMake
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
+```
+
+If you don't use git or dislike submodules you can copy the files in [cmake directory](cmake) into your repository. *Be careful and keep updates in mind!*
+
+Now you can simply run ```find_package``` in your CMake files:
+```CMake
+find_package(Sanitizers)
+```
+
+
+## Usage
+
+You can enable the sanitizers with ``SANITIZE_ADDRESS``, ``SANITIZE_MEMORY``, ``SANITIZE_THREAD`` or ``SANITIZE_UNDEFINED`` options in your CMake configuration. You can do this by passing e.g. ``-DSANITIZE_ADDRESS=On`` on your command line or with your graphical interface.
+
+If sanitizers are supported by your compiler, the specified targets will be build with sanitizer support. If your compiler has no sanitizing capabilities (I asume intel compiler doesn't) you'll get a warning but CMake will continue processing and sanitizing will simply just be ignored.
+
+#### Compiler issues
+
+Different compilers may be using different implementations for sanitizers. If you'll try to sanitize targets with C and Fortran code but don't use gcc & gfortran but clang & gfortran, this will cause linking problems. To avoid this, such problems will be detected and sanitizing will be disabled for these targets.
+
+Even C only targets may cause problems in certain situations. Some problems have been seen with AddressSanitizer for preloading or dynamic linking. In such cases you may try the ``SANITIZE_LINK_STATIC`` to link sanitizers for gcc static.
+
+
+
+## Build targets with sanitizer support
+
+To enable sanitizer support you simply have to add ``add_sanitizers(<TARGET>)`` after defining your target. To provide a sanitizer blacklist file you can use the ``sanitizer_add_blacklist_file(<FILE>)`` function:
+```CMake
+find_package(Sanitizers)
+
+sanitizer_add_blacklist_file("blacklist.txt")
+
+add_executable(some_exe foo.c bar.c)
+add_sanitizers(some_exe)
+
+add_library(some_lib foo.c bar.c)
+add_sanitizers(some_lib)
+```
+
+## Run your application
+
+The sanitizers check your program, while it's running. In some situations (e.g. LD_PRELOAD your target) it might be required to preload the used AddressSanitizer library first. In this case you may use the ``asan-wrapper`` script defined in ``ASan_WRAPPER`` variable to execute your application with ``${ASan_WRAPPER} myexe arg1 ...``.
+
+
+## Contribute
+
+Anyone is welcome to contribute. Simply fork this repository, make your changes **in an own branch** and create a pull-request for your change. Please do only one change per pull-request.
+
+You found a bug? Please fill out an [issue](https://github.com/arsenm/sanitizers-cmake/issues) and include any data to reproduce the bug.
+
+
+#### Contributors
+
+* [Matt Arsenault](https://github.com/arsenm)
+* [Alexander Haase](https://github.com/alehaa)

--- a/cmake/add_simulator.cmake
+++ b/cmake/add_simulator.cmake
@@ -67,6 +67,9 @@ function(build_simcore _targ)
         # Make sure that the top-level directory is part of the libary's include path:
         target_include_directories("${lib}" PUBLIC "${CMAKE_SOURCE_DIR}")
 
+        # And optional sanitizers...
+        add_sanitizers(${_targ})
+
         if (SIMH_INT64)
             target_compile_definitions(${lib} PUBLIC USE_INT64)
         endif (SIMH_INT64)
@@ -200,6 +203,7 @@ function (simh_executable_template _targ)
     )
     target_compile_options(${_targ} PRIVATE ${EXTRA_TARGET_CFLAGS})
     target_link_options(${_targ} PRIVATE ${EXTRA_TARGET_LFLAGS})
+    add_sanitizers(${_targ})
 
     if (MINGW)
         ## target_compile_options(${_targ} PUBLIC "-fms-extensions")

--- a/cmake/asan-wrapper
+++ b/cmake/asan-wrapper
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# This script is a wrapper for AddressSanitizer. In some special cases you need
+# to preload AddressSanitizer to avoid error messages - e.g. if you're
+# preloading another library to your application. At the moment this script will
+# only do something, if we're running on a Linux platform. OSX might not be
+# affected.
+
+
+# Exit immediately, if platform is not Linux.
+if [ "$(uname)" != "Linux" ]
+then
+    exec $@
+fi
+
+
+# Get the used libasan of the application ($1). If a libasan was found, it will
+# be prepended to LD_PRELOAD.
+libasan=$(ldd $1 | grep libasan | sed "s/^[[:space:]]//" | cut -d' ' -f1)
+if [ -n "$libasan" ]
+then
+    if [ -n "$LD_PRELOAD" ]
+    then
+        export LD_PRELOAD="$libasan:$LD_PRELOAD"
+    else
+        export LD_PRELOAD="$libasan"
+    fi
+fi
+
+# Execute the application.
+exec $@

--- a/cmake/cmake-builder.ps1
+++ b/cmake/cmake-builder.ps1
@@ -162,6 +162,10 @@ param (
     [Parameter(Mandatory=$false)]
     [switch] $lto            = $false,
 
+    ## Enable sanitizers
+    [Parameter(Mandatory=$false)]
+    [string] $sanitizer      = "",
+
     ## Turn on maximal compiler warnings for Debug builds (e.g. "-Wall" or "/W3")
     [Parameter(Mandatory=$false)]
     [switch] $debugWall      = $false,
@@ -449,6 +453,19 @@ if (($scriptPhases -contains "generate") -or ($scriptPhases -contains "build"))
     if (![String]::IsNullOrEmpty($cpack_suffix))
     {
         $generateArgs += @("-DSIMH_PACKAGE_SUFFIX:Bool=${cpack_suffix}")
+    }
+
+    ## Add sanitizer(s)
+    foreach ($santhing in $sanitizer.Split(',')) {
+        switch -exact ($santhing)
+        {
+            "address" {
+                $generateArgs += @("-DSANITIZE_ADDRESS:Bool=On")
+            }
+            default {
+                Write-Host "** Unknown sanitizer option: ${santhing}, ignoring"
+            }
+        }
     }
 
     $buildArgs     =  @("--build", "${buildDir}", "--config", "${config}")

--- a/cmake/cmake-builder.sh
+++ b/cmake/cmake-builder.sh
@@ -34,6 +34,12 @@ Configure and build simh simulators on Linux and *nix-like platforms.
 --lto             Enable Link Time Optimization (LTO) in Release builds
 --debugWall       Enable maximal warnings in Debug builds
 --cppcheck        Enable cppcheck static code analysis rules
+--sanitizer       Enable a santizer. Only one sanitizer can be enabled at
+                  a time. Valid sanitizers are:
+                    address [ASan  -- address sanitizer]
+                    memory  [MSan  -- memory sanitizer]
+                    thread  [TSan  -- thread sanitizer]
+                    undef   [UBSan -- undefined behavior sanitizer]
 
 --cpack_suffix    Specify CPack's packaging suffix, e.g., "ubuntu-22.04"
                   to produce the "simh-4.1.0-ubuntu-22.04.deb" Debian
@@ -69,6 +75,7 @@ buildFlavor=
 buildSubdir=
 buildConfig=Release
 testArgs=
+testTimeout=180
 notest=no
 buildParallel=no
 generateOnly=
@@ -78,6 +85,7 @@ installOnly=
 verboseMode=
 simTarget=
 cpack_suffix=
+sanitizer=
 
 ## CMake supports "-S" flag (implies -B works as well.) Otherwise, it's
 ## the older invocation command line.
@@ -160,7 +168,7 @@ fi
 
 longopts=clean,help,flavor:,config:,nonetwork,novideo,notest,parallel,generate,testonly
 longopts=${longopts},noinstall,installonly,verbose,target:,lto,debugWall,cppcheck,cpack_suffix:
-longopts=${longopts},cache,no-aio,no-aio-intrinsics
+longopts=${longopts},cache,no-aio,no-aio-intrinsics,sanitizer:
 
 ARGS=$(${getopt_prog} --longoptions $longopts --options xhf:c:pg -- "$@")
 if [ $? -ne 0 ] ; then
@@ -290,6 +298,20 @@ while true; do
             simTarget="${simTarget} $2"
             shift 2
             ;;
+        --sanitizer)
+            if [ x"${sanitizer}" != x ]; then
+                showHelp "Only one sanitizer can be enabled at a time, already using ${sanitizer}"
+            fi 
+            case $2 in
+            address|memory|thread|undef)
+                sanitizer=$2
+                ;;
+            *)
+                showHelp "Unknown sanitizer option: $2"
+                ;;
+            esac
+            shift 2
+            ;;
         --)
             ## End of options. we'll ignore.
             shift
@@ -305,6 +327,29 @@ if [ "x${buildSubdir}" = x ]; then
   echo ""
   showHelp
 fi
+
+if [ x"${sanitizer}" != x ]; then
+    ## Adjust the test timeout because the sanitizers have add'l
+    ## runtime overhead (at least 2x)
+    testTimeout=600
+fi
+
+case "${sanitizer}" in
+address)
+    generateArgs="${generateArgs} -DSANITIZE_ADDRESS:Bool=On"
+    ;;
+memory)
+    generateArgs="${generateArgs} -DSANITIZE_MEMORY:Bool=On"
+    ;;
+thread)
+    generateArgs="${generateArgs} -DSANITIZE_THREAD:Bool=On"
+    ;;
+undef)
+    generateArgs="${generateArgs} -DSANITIZE_UNDEFINED:Bool=On"
+    ;;
+*)
+    ;;
+esac
 
 ## Determine the SIMH top-level source directory:
 simhTopDir=$(${dirname} $(${realpath} $0))
@@ -331,8 +376,8 @@ if [[ ! -d ${buildSubdir} ]]; then
     mkdir ${buildSubdir}
 fi
 
-## Setup test arguments (and add parallel later)
-testArgs="-C ${buildConfig} --timeout 180 --output-on-failure"
+## Setup test arguments (and add parallel later).
+testArgs="-C ${buildConfig} --timeout ${testTimeout} --output-on-failure"
 
 ## Parallel only applies to the unix flavor. GNU make will overwhelm your
 ## machine if the number of jobs isn't capped.
@@ -342,8 +387,9 @@ if [[ x"$canParallel" = xyes ]] ; then
           buildArgs="${buildArgs} --parallel"
 	  buildPostArgs="${buildPostArgs} -j 8"
 	}
-
-    # Don't execute ctest in parallel...
+    
+    ## Don't execute ctest in parallel... interleaved output and output
+    ## correlation is confusing.
     # [ x${canTestParallel} = xyes ] && {
     #    testArgs="${testArgs} --parallel 4"
     # }

--- a/cmake/os-features.cmake
+++ b/cmake/os-features.cmake
@@ -205,3 +205,6 @@ if (CYGWIN)
     target_compile_definitions(os_features INTERFACE HAVE_WINMM)
   endif ()
 endif ()
+
+## Sanitizer support
+find_package(Sanitizers)

--- a/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitize-helpers.cmake
@@ -1,0 +1,180 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Helper function to get the language of a source file.
+function (sanitizer_lang_of_source FILE RETURN_VAR)
+    get_filename_component(LONGEST_EXT "${FILE}" EXT)
+    # If extension is empty return. This can happen for extensionless headers
+    if("${LONGEST_EXT}" STREQUAL "")
+       set(${RETURN_VAR} "" PARENT_SCOPE)
+       return()
+    endif()
+    # Get shortest extension as some files can have dot in their names
+    string(REGEX REPLACE "^.*(\\.[^.]+)$" "\\1" FILE_EXT ${LONGEST_EXT})
+    string(TOLOWER "${FILE_EXT}" FILE_EXT)
+    string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
+
+    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach (LANG ${ENABLED_LANGUAGES})
+        list(FIND CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS "${FILE_EXT}" TEMP)
+        if (NOT ${TEMP} EQUAL -1)
+            set(${RETURN_VAR} "${LANG}" PARENT_SCOPE)
+            return()
+        endif ()
+    endforeach()
+
+    set(${RETURN_VAR} "" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to get compilers used by a target.
+function (sanitizer_target_compilers TARGET RETURN_VAR)
+    # Check if all sources for target use the same compiler. If a target uses
+    # e.g. C and Fortran mixed and uses different compilers (e.g. clang and
+    # gfortran) this can trigger huge problems, because different compilers may
+    # use different implementations for sanitizers.
+    set(BUFFER "")
+    get_target_property(TSOURCES ${TARGET} SOURCES)
+    foreach (FILE ${TSOURCES})
+        # If expression was found, FILE is a generator-expression for an object
+        # library. Object libraries will be ignored.
+        string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _file ${FILE})
+        if ("${_file}" STREQUAL "")
+            sanitizer_lang_of_source(${FILE} LANG)
+            if (LANG)
+                list(APPEND BUFFER ${CMAKE_${LANG}_COMPILER_ID})
+            endif ()
+        endif ()
+    endforeach ()
+
+    list(REMOVE_DUPLICATES BUFFER)
+    set(${RETURN_VAR} "${BUFFER}" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to check compiler flags for language compiler.
+function (sanitizer_check_compiler_flag FLAG LANG VARIABLE)
+
+    if (${LANG} STREQUAL "C")
+        include(CheckCCompilerFlag)
+        check_c_compiler_flag("${FLAG}" ${VARIABLE})
+
+    elseif (${LANG} STREQUAL "CXX")
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("${FLAG}" ${VARIABLE})
+
+    elseif (${LANG} STREQUAL "Fortran")
+        # CheckFortranCompilerFlag was introduced in CMake 3.x. To be compatible
+        # with older Cmake versions, we will check if this module is present
+        # before we use it. Otherwise we will define Fortran coverage support as
+        # not available.
+        include(CheckFortranCompilerFlag OPTIONAL RESULT_VARIABLE INCLUDED)
+        if (INCLUDED)
+            check_fortran_compiler_flag("${FLAG}" ${VARIABLE})
+        elseif (NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "Performing Test ${VARIABLE}")
+            message(STATUS "Performing Test ${VARIABLE}"
+                " - Failed (Check not supported)")
+        endif ()
+    endif()
+
+endfunction ()
+
+
+# Helper function to test compiler flags.
+function (sanitizer_check_compiler_flags FLAG_CANDIDATES NAME PREFIX)
+    set(CMAKE_REQUIRED_QUIET ${${PREFIX}_FIND_QUIETLY})
+
+    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach (LANG ${ENABLED_LANGUAGES})
+        # Sanitizer flags are not dependend on language, but the used compiler.
+        # So instead of searching flags foreach language, search flags foreach
+        # compiler used.
+        set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+        if (COMPILER AND NOT DEFINED ${PREFIX}_${COMPILER}_FLAGS)
+            foreach (FLAG ${FLAG_CANDIDATES})
+                if(NOT CMAKE_REQUIRED_QUIET)
+                    message(STATUS "Try ${COMPILER} ${NAME} flag = [${FLAG}]")
+                endif()
+
+                set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+                unset(${PREFIX}_FLAG_DETECTED CACHE)
+                sanitizer_check_compiler_flag("${FLAG}" ${LANG}
+                    ${PREFIX}_FLAG_DETECTED)
+
+                if (${PREFIX}_FLAG_DETECTED)
+                    # If compiler is a GNU compiler, search for static flag, if
+                    # SANITIZE_LINK_STATIC is enabled.
+                    if (SANITIZE_LINK_STATIC AND (${COMPILER} STREQUAL "GNU"))
+                        string(TOLOWER ${PREFIX} PREFIX_lower)
+                        sanitizer_check_compiler_flag(
+                            "-static-lib${PREFIX_lower}" ${LANG}
+                            ${PREFIX}_STATIC_FLAG_DETECTED)
+
+                        if (${PREFIX}_STATIC_FLAG_DETECTED)
+                            set(FLAG "-static-lib${PREFIX_lower} ${FLAG}")
+                        endif ()
+                    endif ()
+
+                    set(${PREFIX}_${COMPILER}_FLAGS "${FLAG}" CACHE STRING
+                        "${NAME} flags for ${COMPILER} compiler.")
+                    mark_as_advanced(${PREFIX}_${COMPILER}_FLAGS)
+                    break()
+                endif ()
+            endforeach ()
+
+            if (NOT ${PREFIX}_FLAG_DETECTED)
+                set(${PREFIX}_${COMPILER}_FLAGS "" CACHE STRING
+                    "${NAME} flags for ${COMPILER} compiler.")
+                mark_as_advanced(${PREFIX}_${COMPILER}_FLAGS)
+
+                message(WARNING "${NAME} is not available for ${COMPILER} "
+                        "compiler. Targets using this compiler will be "
+                        "compiled without ${NAME}.")
+            endif ()
+        endif ()
+    endforeach ()
+endfunction ()
+
+
+# Helper to assign sanitizer flags for TARGET and only for the Debug build configuration.
+function (sanitizer_add_flags TARGET NAME PREFIX)
+    # Get list of compilers used by target and check, if sanitizer is available
+    # for this target. Other compiler checks like check for conflicting
+    # compilers will be done in add_sanitizers function.
+    sanitizer_target_compilers(${TARGET} TARGET_COMPILER)
+    list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+    if ("${${PREFIX}_${TARGET_COMPILER}_FLAGS}" STREQUAL "")
+        return()
+    endif()
+
+    separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS} ${SanBlist_${TARGET_COMPILER}_FLAGS}")
+    target_compile_options(${TARGET} PUBLIC "$<$<CONFIG:Debug>:${flags_list}>")
+    target_compile_options(${TARGET} PUBLIC "$<$<CONFIG:Release>:${flags_list}>")
+
+    separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
+    target_link_options(${TARGET} PUBLIC "$<$<CONFIG:Debug>:${flags_list}>")
+    target_link_options(${TARGET} PUBLIC "$<$<CONFIG:Release>:${flags_list}>")
+
+endfunction ()


### PR DESCRIPTION
Add ASan [address], MSan [memory], TSan [thread] and UBSan [undefined behavior] to the cmake-builder scripts. These are intended for developer usage only to aid in debugging and general code improvement/diagnosis.

Linux, macOS: ASan, MSan, TSan and UBSan.
Microsoft: ASan only.