### PR TITLE
TT2500: Debugging and reduce type slice warnings.

### DIFF
--- a/tt2500/tt2500_cpu.c
+++ b/tt2500/tt2500_cpu.c
@@ -162,8 +162,8 @@ static uint16 cpu_ars (uint16 data, uint16 n)
 {
   uint32 sign = 0;
   if (data & 0100000)
-    sign = 0177777 << 16;
-  return (data >> n) + (sign >> n);
+    sign = 0177777u << 16;
+  return (data >> n) + ((uint16) (sign >> n));
 }
 
 uint16 cpu_alu (uint16 insn, uint16 op, uint16 adata, uint16 bdata)

--- a/tt2500/tt2500_dpy.c
+++ b/tt2500/tt2500_dpy.c
@@ -210,7 +210,7 @@ static t_stat dpy_reset (DEVICE *dptr)
 
 void dpy_magic (uint16 xr, uint16 *r2, uint16 *r3, uint16 r4, uint16 r5)
 {
-  uint32 x = *r2, y = *r3;
+  uint16 x = *r2, y = *r3;
   uint16 x0, y0, x1, y1, dx, dy;
 
   sim_debug (DBG_VEC, &dpy_dev, "MAGIC %06o\n", xr);

--- a/tt2500/tt2500_tv.c
+++ b/tt2500/tt2500_tv.c
@@ -108,11 +108,12 @@ tv_reset (DEVICE *dptr)
 
 static void tv_character (int row, int col, uint8 c, uint8 *font)
 {
-  uint16 i, j, pixels, address;
+  size_t i, address;
 
   address = 16 * c;
   for (i = 0; i < 16; i++) {
-    pixels = font[address + i];
+    size_t j, pixels = font[address + i];
+
     for (j = 0; j < 8; j++) {
       surface[8 * (72 * i + col) + j] = palette[(pixels >> 7) & 1];
       pixels <<= 1;

--- a/tt2500/tt2500_uart.c
+++ b/tt2500/tt2500_uart.c
@@ -113,7 +113,7 @@ uart_r_svc(UNIT *uptr)
   if (uptr->fileref != NULL) {
     unsigned char buf;
     if (sim_fread (&buf, 1, 1, uptr->fileref) == 1) {
-      sim_debug (DBG_RX, &uart_dev, "Received character %03o\n", buf);
+      sim_debug (DBG_RX, &uart_dev, "Received character %03o (%c)\n", buf, isprint(buf) ? buf : ' ');
       RBUF = buf;
       flag_on (INT_RRD);
     }
@@ -122,7 +122,7 @@ uart_r_svc(UNIT *uptr)
     ch = tmxr_getc_ln (&uart_ldsc);
     if (ch & TMXR_VALID) {
       RBUF = sim_tt_inpcvt (ch, TT_GET_MODE (uart_unit[0].flags));
-      sim_debug (DBG_RX, &uart_dev, "Received character %03o\n", RBUF);
+      sim_debug (DBG_RX, &uart_dev, "TMXR received character %03o (%c)\n", RBUF, isprint(RBUF) ? RBUF : ' ');
       flag_on (INT_RRD);
       return SCPE_OK;
     }


### PR DESCRIPTION
- Debug: Output the character received, if printable.
- Eliminate type slicing warnings (uint32 -> uint16)