### PR TITLE
sigma: return corrrect CC on line disconnect

### DIFF
--- a/sigma/sigma_coc.c
+++ b/sigma/sigma_coc.c
@@ -403,7 +403,9 @@ else {                                                  /* receive */
         }
     if (mux_sta[ln] & MUXL_RBP)                         /* break pending? */
         CC = CC3|CC4;
-    else CC = mux_ldsc[ln].rcve? CC4: CC3;
+    else if (mux_ldsc[ln].conn)
+        CC = mux_ldsc[ln].rcve? CC4: CC3;
+    else CC = 0;
     }
 return 0;
 }    


### PR DESCRIPTION
Fix sigma_coc.c to return CC=0 when line has disconnected. This problem was reported as issue #12 on kenrector/Sigma-cpv-kit concerning line hung after telnet quit.