### PR TITLE
vmnet.framework support on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,9 @@ option(WITH_VDE
 option(WITH_TAP
        "Enable (=1)/disable (=0) TAP/TUN device network support. (def: enabled)"
        TRUE)
+option(WITH_VMNET
+       "Enable (=1)/disable (=0) macOS vmnet.framework network support. (def: enabled)"
+       TRUE)
 option(WITH_VIDEO
        "Enable (=1)/disable (=0) simulator display and graphics support (def: enabled)"
        TRUE)

--- a/cmake/dep-link.cmake
+++ b/cmake/dep-link.cmake
@@ -351,6 +351,11 @@ if (WITH_NETWORK)
         list(APPEND NETWORK_PKG_STATUS "NAT(SLiRP)")
     endif (WITH_SLIRP)
 
+    if (WITH_VMNET AND APPLE)
+        target_link_libraries(simh_network INTERFACE "-framework vmnet")
+        target_compile_definitions(simh_network INTERFACE HAVE_VMNET_NETWORK)
+    endif(WITH_VMNET AND APPLE)
+
     ## Finally, set the network runtime
     if (NOT network_runtime)
         ## Default to USE_SHARED... USE_NETWORK is deprecated.

--- a/cmake/dep-link.cmake
+++ b/cmake/dep-link.cmake
@@ -352,8 +352,33 @@ if (WITH_NETWORK)
     endif (WITH_SLIRP)
 
     if (WITH_VMNET AND APPLE)
+        # CMAKE_OSX_DEPLOYMENT_TARGET is attractive, but not set by default.
+        # See what we're using, either by default or what the user has set.
+        check_c_source_compiles(
+            "
+            #include <Availability.h>
+            #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED < 101000
+            #error macOS too old
+            #endif
+            int main(int argc, char **argv) { return 0; }
+            " TARGETING_MACOS_10_10)
+        if (NOT TARGETING_MACOS_10_10)
+        message(FATAL_ERROR "vmnet.framework requires targeting macOS 10.10 or newer")
+        endif()
+
+        # vmnet requires blocks for its callback parameter, even in vanilla C.
+        # This is only supported in clang, not by GCC. It's default in clang,
+        # but we should be clear about it. Do a feature instead of compiler
+        # check anyways though, in case GCC does add it eventually.
+        check_c_compiler_flag(-fblocks HAVE_C_BLOCKS)
+        if (NOT HAVE_C_BLOCKS)
+            message(FATAL_ERROR "vmnet.framework requires blocks support in the C compiler")
+        endif()
+        target_compile_options(simh_network INTERFACE -fblocks)
+
         target_link_libraries(simh_network INTERFACE "-framework vmnet")
         target_compile_definitions(simh_network INTERFACE HAVE_VMNET_NETWORK)
+        list(APPEND NETWORK_PKG_STATUS "macOS vmnet.framework")
     endif(WITH_VMNET AND APPLE)
 
     ## Finally, set the network runtime

--- a/makefile
+++ b/makefile
@@ -1059,6 +1059,13 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
         NETWORK_CCDEFS += -DUSE_NETWORK
       endif
     endif
+    # XXX: Check for the target version of macOS, check for -fblocks
+    ifeq (Darwin,$(OSTYPE))
+      # Provide support for macOS vmnet.framework (requires 10.10)
+      NETWORK_CCDEFS += -fblocks -DHAVE_VMNET_NETWORK
+      NETWORK_LAN_FEATURES += vmnet.framework
+      NETWORK_LDFLAGS += -framework vmnet
+    endif
     ifeq (slirp,$(shell if ${TEST} -e slirp_glue/sim_slirp.c; then echo slirp; fi))
       NETWORK_CCDEFS += -Islirp -Islirp_glue -Islirp_glue/qemu -DHAVE_SLIRP_NETWORK -DUSE_SIMH_SLIRP_DEBUG slirp/*.c slirp_glue/*.c
       NETWORK_LAN_FEATURES += NAT(SLiRP)

--- a/sim_ether.c
+++ b/sim_ether.c
@@ -379,12 +379,12 @@
 #include <unistd.h>
 #endif
 
+#define MAX(a,b) (((a) > (b)) ? (a) : (b))
+
 // Declare earlier than other implementations
 #ifdef HAVE_VMNET_NETWORK
 #include <vmnet/vmnet.h>
 #endif
-
-#define MAX(a,b) (((a) > (b)) ? (a) : (b))
 
 /* Internal routine - forward declaration */
 static int _eth_get_system_id (char *buf, size_t buf_size);

--- a/sim_ether.h
+++ b/sim_ether.h
@@ -265,6 +265,7 @@ struct eth_device {
 #define ETH_API_VDE  3                                  /* VDE API in use */
 #define ETH_API_UDP  4                                  /* UDP API in use */
 #define ETH_API_NAT  5                                  /* NAT (SLiRP) API in use */
+#define ETH_API_VMN  6                                  /* Apple vmnet.framework in use */
   ETH_PCALLBACK read_callback;                          /* read callback function */
   ETH_PCALLBACK write_callback;                         /* write callback function */
   ETH_PACK*     read_packet;                            /* read packet */


### PR DESCRIPTION
macOS has no built-in tun/tap support; third-party extensions to do so require more hoops to jump through as Apple (justifiably) makes it harder to use third-party kexts. The situation for virtual networking is thus clumsy, relying on pcap/VDE, or dealing with the limitations of slirp or the UDP tunneling. This PR adds support for [vmnet](https://developer.apple.com/documentation/vmnet?language=objc), an alternative built into the OS. It provides host-only and shared NAT layer 2 virtual networks, as well as bridging virtual interfaces to physical interfaces.

vmnet requires macOS 10.10 for basic functionality, and 10.15 for bridged networks.

Documentation and SCP help has also been updated.

This has been tested with the following scenarios on macOS 15:

- Netbooting a MicroVAX 3900 in simh from an InfoServer 150 in simh (over MOP); the system was able to install OpenVMS 7.3.
- Installing NetBSD/vax 10.1. NetBSD is able to acquire IPv4 and IPv6 addresses via DHCP, and I can telnet into the VAX via IPv6.