### PR TITLE
Github CI/CD updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,25 +40,22 @@ jobs:
           - scelbi 3b2 i701 i704 i7010 i7070 i7080 i7090 sigma uc15 i650 sel32 intel-mds ibm1130
     steps:
       - uses: actions/checkout@v4
-      ## Workaround for remnant symlinks in /usr/local pointing back to
-      ## macOS frameworks.
-      ##
-      ## Future: Will have to keep an eye on SDL_ttf's Python dependency
-      ## so that the correct/appropriate Python version is removed.
-      - name: Remnant symlink cleanup (macOS)
+
+      ## Nuke homebrew and start with a clean instance:
+      - name: Reinstall HomeBrew (macOS)
         if: ${{runner.os == 'macOS'}}
         run: |
-          brew unlink python@3 || true
-          brew uninstall --ignore-dependencies python@3 || true
-          brew unlink python@3.12 || true
-          brew uninstall --ignore-dependencies python@3.12 || true
-          for f in $(find /usr/local/bin -type l -print); do \
-            (readlink $f | grep -q -s "/Library") && echo Removing "$f" && rm -f "$f"; \
-          done || exit 0
+          /usr/bin/sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
+          [ -d /opt/homebrew ] && ( sudo rm -rf /opt/homebrew/* || true )
+          [ -d /usr/local ]    && ( sudo rm -rf /usr/local/*    || true )
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
       ## Install our regular dependencies.
       - name: Install dependencies (macOS)
         if: ${{runner.os == 'macOS'}}
-        run: sh -ex .travis/deps.sh osx
+        run: |
+          sh -ex .travis/deps.sh osx
+
       - name: Install dependencies (Linux)
         if: ${{runner.os == 'Linux'}}
         run: sh -ex .travis/deps.sh linux

--- a/.github/workflows/cmake-builds.yml
+++ b/.github/workflows/cmake-builds.yml
@@ -17,7 +17,7 @@ jobs:
       # (*) "artefact" for the rest of the Anglosphere
       #-
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
 
 
   cmake-macOS:
-    name: macOS 12+
+    name: macOS
     runs-on: ${{ matrix.os }}
     strategy:
       #-
@@ -57,8 +57,10 @@ jobs:
       # that the build produces.
       #
       # (*) "artefact" for the rest of the Anglosphere -
+      #
+      # As of 18 NOV 2024, Github deprecated macos-12.
       matrix:
-        os: [macos-12, macos-13, macos-latest]
+        os: [macos-13, macos-14, macos-latest]
 
     env:
       CPACK_SUFFIX: ${{matrix.os != 'macos-14' && 'x86_64' || 'm1'}}.${{matrix.os}}
@@ -66,26 +68,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    ## Workaround for remnant symlinks in /usr/local pointing back to
-    ## macOS frameworks.
-    ##
-    ## Future: Will have to keep an eye on SDL_ttf's Python dependency
-    ## so that the correct/appropriate Python version is removed.
-    ##
-    ## Redirect stderr to /dev/null so that GH doesn't emit useless failure
-    ## messages.
-    - name: Remnant symlink cleanup
+    ## Nuke homebrew and start with a clean instance.
+    - name: Reinstall HomeBrew (macOS)
       run: |
-        brew unlink python@3 2> /dev/null || true
-        brew uninstall --ignore-dependencies python@3 2> /dev/null || true
-        brew unlink python@3.12 2> /dev/null || true
-        brew uninstall --ignore-dependencies python@3.12 2> /dev/null || true
-        for f in $(find /usr/local/bin -type l -print); do \
-          (readlink $f | grep -q -s "/Library") && echo Removing "$f" && rm -f "$f"; \
-        done || exit 0
+        /usr/bin/sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
+        [ -d /opt/homebrew ] && ( sudo rm -rf /opt/homebrew/* || true )
+        [ -d /usr/local ]    && ( sudo rm -rf /usr/local/*    || true )
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
     - name: Install dependencies
-      run: sh -ex .travis/deps.sh osx
+      run: |
+        sh -ex .travis/deps.sh osx
 
     - name: cmake-builder.sh
       run: |
@@ -192,6 +185,17 @@ jobs:
   cmake-vs2022:
     name: VS 2022 Win10 native VCPKG
     runs-on: windows-latest
+    strategy:
+      #-
+      # The CMake builds produce artifacts (*) and the runner image's name is
+      # used in the artifact's name, simh-4.1.0-x86_64-ubuntu-20.04.deb.
+      # Consequently, each runner image is enumerated for each artifact (*)
+      # that the build produces.
+      #
+      # (*) "artefact" for the rest of the Anglosphere
+      #-
+      matrix:
+        build: [vs2022]
     steps:
     - uses: actions/checkout@v4
     - name: vs2022 build
@@ -209,34 +213,36 @@ jobs:
           Push-Location $env:VCPKG_ROOT
           git pull
           Pop-Location
-          ./cmake/cmake-builder.ps1 -flavor vs2022 -config Release -clean -lto -verbose -notest -cpack_suffix win32-native
+          ./cmake/cmake-builder.ps1 -flavor ${{matrix.build}} -config Release -clean -lto -verbose `
+                -notest `
+                -cpack_suffix ${{matrix.build}}
     - name: SIMH simulator suite test
       shell: pwsh
       run: |
-          ./cmake/cmake-builder.ps1 -flavor vs2022 -config Release -testOnly
+          ./cmake/cmake-builder.ps1 -flavor ${{matrix.build}} -config Release -testOnly
     ## Install isn't strictly necessary, but it's a good way to see what dependencies
     ## (IMPORTED_RUNTIME_ARTIFACTS) get installed.
     - name: Install
       shell: pwsh
       run: |
-        cmake/cmake-builder.ps1 -config Release -flavor vs2022 -installOnly
+        cmake/cmake-builder.ps1 -config Release -flavor ${{matrix.build}} -installOnly
     - name: SIMH packaging
       shell: pwsh
       run: |
-          cd cmake\build-vs2022
+          cd cmake\build-${{matrix.build}}
           cpack -G "NSIS;WIX;ZIP" -C Release
     - name: Upload ZIP
       uses: actions/upload-artifact@v4
       with:
-        name: simh-4.1.0-win32-vs2022.zip
-        path: cmake/build-vs2022/simh-4.1.0-win32-native.zip
+        name: simh-4.1.0-${{matrix.build}}.zip
+        path: cmake/build-${{matrix.build}}/simh-4.1.0-${{matrix.build}}.zip
     - name: Upload EXE installer
       uses: actions/upload-artifact@v4
       with:
-        name: simh-4.1.0-win32-vs2022.exe
-        path: cmake/build-vs2022/simh-4.1.0-win32-native.exe
+        name: simh-4.1.0-${{matrix.build}}.exe
+        path: cmake/build-${{matrix.build}}/simh-4.1.0-${{matrix.build}}.exe
     - name: Upload MSI installer
       uses: actions/upload-artifact@v4
       with:
-        name: simh-4.1.0-win32-vs2022.msi
-        path: cmake/build-vs2022/simh-4.1.0-win32-native.msi
+        name: simh-4.1.0-${{matrix.build}}.msi
+        path: cmake/build-${{matrix.build}}/simh-4.1.0-${{matrix.build}}.msi

--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -27,7 +27,20 @@ install_linux() {
     sudo apt-get install -ym libegl1-mesa-dev libgles2-mesa-dev
     sudo apt-get install -ym libsdl2-dev libfreetype6-dev libsdl2-ttf-dev
     sudo apt-get install -ym libpcap-dev libvdeplug-dev
-    sudo apt-get install -ym cmake cmake-data
+    sudo apt-get install -ym cmake cmake-data ninja-build
+}
+
+install_mingw32() {
+    ## Doesn't have libpcap or cmake's extra modules. Not that this
+    ## makes much of a difference.
+    pacman -S --needed mingw-w64-i686-ninja \
+	mingw-w64-i686-cmake \
+        mingw-w64-i686-gcc \
+	mingw-w64-i686-make \
+        mingw-w64-i686-pcre \
+	mingw-w64-i686-freetype \
+        mingw-w64-i686-SDL2 \
+	mingw-w64-i686-SDL2_ttf
 }
 
 install_mingw64() {
@@ -71,14 +84,15 @@ install_clang64() {
 
 
 case "$1" in
-  osx|macports|linux|mingw64|ucrt64|clang64)
+  osx|macports|linux|mingw32|mingw64|ucrt64|clang64)
     install_"$1"
     ;;
   arch-linux)
     install_arch_linux
     ;;
   *)
-    echo "$0: Need an operating system name: osx, arch-linux, linux, mingw64 or ucrt64"
+    echo "$0: Need an operating system name:"
+    typeset -f | sed -e '/^install_/!d' -e 's/^install_/  - /' -e 's/ ()//' | sort
     exit 1
     ;;
 esac

--- a/sim_fio.c
+++ b/sim_fio.c
@@ -127,22 +127,89 @@ if (sim_end || (count == 0) || (size == sizeof (char)))
 sim_byte_swap_data (bptr, size, count);
 }
 
+#if defined(__GNUC__) || defined(__clang__)
+#define sim_bswap16 __builtin_bswap16
+#define sim_bswap32 __builtin_bswap32
+#define sim_bswap64 __builtin_bswap64
+
+#define USE_BSWAP_INTRINSIC
+#elif defined(_MSC_VER)
+#define sim_bswap16 _byteswap_ushort
+#define sim_bswap32 _byteswap_ulong
+#define sim_bswap64 _byteswap_uint64
+
+#define USE_BSWAP_INTRINSIC
+#endif
+
 void sim_byte_swap_data (void *bptr, size_t size, size_t count)
 {
-uint32 j;
-int32 k;
-unsigned char by, *sptr, *dptr;
+    size_t j;
+    uint8 *sptr = (uint8 *) bptr;
 
-if (sim_end || (count == 0) || (size == sizeof (char)))
-    return;
-for (j = 0, dptr = sptr = (unsigned char *) bptr;       /* loop on items */
-     j < count; j++) {
-    for (k = (int32)(size - 1); k >= (((int32) size + 1) / 2); k--) {
-        by = *sptr;                                     /* swap end-for-end */
-        *sptr++ = *(dptr + k);
-        *(dptr + k) = by;
+    if (sim_end || (count == 0) || (size == sizeof (char)))
+        return;
+
+    /* Note: Restructured this code so that GCC Link Time Optimization doesn't generate
+     * spurious buffer overwrite messages.
+     *
+     * LTO tries to inline this function where it's used and ends up evaluating the loop.
+     * It's clearly a LTO bug that needs to be worked around as opposed to waiting for a
+     * compiler update (and SIMH can't guarantee that users will maintain updated platforms).
+     * 
+     * Output from the compiler looks like:
+     * 
+     * 363 | int32 f, u, comp, cyl, sect, surf;
+     *     |             ^
+     * PDP18B/pdp18b_rp.c:363:13: note: at offset [16, 48] into destination object ‘comp’ of size 4
+     * PDP18B/pdp18b_rp.c:363:13: note: at offset [80, 17179869168] into destination object ‘comp’ of size 4
+     * In function ‘sim_byte_swap_data’,
+     * inlined from ‘sim_byte_swap_data’ at sim_fio.c:130:6,
+     * inlined from ‘sim_buf_swap_data’ at sim_fio.c:127:1,
+     * inlined from ‘sim_fread’ at sim_fio.c:158:1,
+     * inlined from ‘rp_svc’ at PDP18B/pdp18b_rp.c:442:15:
+     * sim_fio.c:142:17: error: writing 4 bytes into a region of size 0 [-Werror=stringop-overflow=]
+     * 142 |         *sptr++ = *(dptr + k);
+     */
+
+    for (j = 0; j < count; j++) {                           /* loop on items */
+#if defined(USE_BSWAP_INTRINSIC)
+        switch (size) {
+        case sizeof(uint16):
+            *((uint16 *) sptr) = sim_bswap16 (*((uint16 *) sptr));
+            break;
+
+        case sizeof(uint32):
+            *((uint32 *) sptr) = sim_bswap32 (*((uint32 *) sptr));
+            break;
+
+        case sizeof(t_uint64):
+            *((t_uint64 *) sptr) = sim_bswap64 (*((t_uint64 *) sptr));
+            break;
+
+        default:
+#endif
+
+            {
+                /* Either there aren't any intrinsics that do byte swapping or
+                 * it's not a well known size. */
+                uint8 *dptr;
+                size_t k;
+                const size_t midpoint = (size + 1) / 2;
+
+                dptr = sptr + size - 1;
+                for (k = size - 1; k >= midpoint; k--) {
+                    uint8 by = *sptr;                       /* swap end-for-end */
+                    *sptr++ = *dptr;
+                    *dptr-- = by;
+                }
+            }
+
+#if defined(USE_BSWAP_INTRINSIC)
+            break;
         }
-    sptr = dptr = dptr + size;                          /* next item */
+#endif
+
+        sptr += size;                                       /* next item */
     }
 }
 
@@ -550,7 +617,7 @@ dwStatus = FormatMessageA (FORMAT_MESSAGE_FROM_SYSTEM|
                            Error,                             //  __in      DWORD dwMessageId,
                            0,                                 //  __in      DWORD dwLanguageId,
                            szMsgBuffer,                       //  __out     LPTSTR lpBuffer,
-                           sizeof (szMsgBuffer) -1,           //  __in      DWORD nSize,
+                           sizeof (szMsgBuffer) - 1,          //  __in      DWORD nSize,
                            NULL);                             //  __in_opt  va_list *Arguments
 if (0 == dwStatus)
     snprintf(szMsgBuffer, sizeof(szMsgBuffer) - 1, "Error Code: 0x%X", Error);


### PR DESCRIPTION
- Nuke and reinstall HomeBrew for macOS builds. Gets around the whole problem of stale links and conflicting packages installed in the GitHub macOS images.

- macOS 12 and Ubuntu 20.04 officially deprecated. Ubuntu 20.04 will be removed from GitHub's runner images on 01 APR 2025.

- .travis/deps.sh: Add mingw32 as a dependency target, enable MinGW64 32-bit builds.

- Work around LTO bug on Ubuntu and macOS compilers, where LTO appears to miscalculate the number of bytes stored when using the default byte swapping 'for' loop. This is a workaround that uses compiler swapping intrinsics for well known sizes that appeases LTO. The alternative is to wait for a compiler fix, which is infeasible.