### PR TITLE
ETH_MAC indirection erratum

### DIFF
--- a/3B2/3b2_ni.c
+++ b/3B2/3b2_ni.c
@@ -557,7 +557,7 @@ t_stat ni_setmac(UNIT *uptr, int32 val, CONST char* cptr, void* desc)
     UNUSED(desc);
 
     status = SCPE_OK;
-    status = eth_mac_scan_ex(&ni.macs[NI_NIC_MAC], cptr, uptr);
+    status = eth_mac_scan_ex(ni.macs[NI_NIC_MAC], cptr, uptr);
 
     if (status == SCPE_OK) {
         eth_filter(ni.eth, ni.filter_count, ni.macs, 0, 0);
@@ -577,7 +577,7 @@ t_stat ni_showmac(FILE* st, UNIT* uptr, int32 val, CONST void* desc)
     UNUSED(val);
     UNUSED(desc);
 
-    eth_mac_fmt(&ni.macs[NI_NIC_MAC], buffer);
+    eth_mac_fmt(ni.macs[NI_NIC_MAC], buffer);
     fprintf(st, "MAC=%s", buffer);
     return SCPE_OK;
 }
@@ -591,12 +591,12 @@ t_stat ni_show_filters(FILE* st, UNIT* uptr, int32 val, CONST void* desc)
     UNUSED(val);
     UNUSED(desc);
 
-    eth_mac_fmt(&ni.macs[NI_NIC_MAC], buffer);
+    eth_mac_fmt(ni.macs[NI_NIC_MAC], buffer);
     fprintf(st, "Physical Address=%s\n", buffer);
     if (ni.filter_count > 0) {
         fprintf(st, "Filters:\n");
         for (i=0; i < ni.filter_count; i++) {
-            eth_mac_fmt((ETH_MAC *) ni.macs[i], buffer);
+            eth_mac_fmt(ni.macs[i], buffer);
             fprintf(st, "[%2d]: %s\n", i, buffer);
         }
         fprintf(st, "\n");
@@ -948,7 +948,7 @@ t_stat ni_attach(UNIT *uptr, CONST char *cptr)
         return status;
     }
 
-    status = eth_check_address_conflict(ni.eth, &ni.macs[NI_NIC_MAC]);
+    status = eth_check_address_conflict(ni.eth, ni.macs[NI_NIC_MAC]);
     if (status != SCPE_OK) {
         sim_debug(DBG_ERR, &ni_dev, "ni_attach failure: mac check\n");
         eth_close(ni.eth);

--- a/VAX/vax_nar.c
+++ b/VAX/vax_nar.c
@@ -81,7 +81,7 @@ t_stat nar_showmac (FILE* st, UNIT* uptr, int32 val, CONST void* desc)
 {
 char buffer[20];
 
-eth_mac_fmt ((ETH_MAC*)nar_mac, buffer);
+eth_mac_fmt (nar_mac, buffer);
 fprintf (st, "MAC=%s", buffer);
 return SCPE_OK;
 }
@@ -92,7 +92,7 @@ t_stat status;
 
 if (!cptr)
     return SCPE_IERR;
-status = eth_mac_scan (&nar_mac, cptr);
+status = eth_mac_scan (nar_mac, cptr);
 if (status != SCPE_OK)
     return status;
 nar_reset (&nar_dev);
@@ -136,7 +136,7 @@ t_stat r;
 
 if (!nar_init) {                                        /* set initial MAC */
     nar_init = TRUE;
-    r = eth_mac_scan (&nar_mac, "08:00:2B:00:00:00/24");
+    r = eth_mac_scan (nar_mac, "08:00:2B:00:00:00/24");
     if (r != SCPE_OK)
         return r;
     }

--- a/VAX/vax_xs.c
+++ b/VAX/vax_xs.c
@@ -645,7 +645,7 @@ xs->var->csr0 = xs->var->csr0 | CSR0_INIT;
 xs->var->csr0 = xs->var->csr0 & ~CSR0_STOP;
 
 /* reset ethernet interface */
-memcpy (xs->var->setup.macs[0], xs->var->mac, sizeof(ETH_MAC));
+eth_copy_mac(xs->var->setup.macs[0], xs->var->mac);
 xs->var->setup.mac_count = 1;
 if (xs->var->etherface)
     eth_filter (xs->var->etherface, xs->var->setup.mac_count,


### PR DESCRIPTION
Pervasive misuse of "ETH_MAC *" (a pointer to an ETH_MAC, aka a 6 element unsigned char array) when a simple "ETH_MAC" is correct.  The best example of this was eth_mac_fmt() in sim_ether.c with the following prototype:

    t_stat eth_mac_fmt (ETH_MAC* const mac, char* strmac)

The first parameter is a pointer to an array of 6 unsigned characters, whereas it really just wants to be a pointer to the first element of the array:

    t_stat eth_mac_scan (const ETH_MAC mac, char* strmac)

The "ETH_MAC *" indirection error also results in subtle memcpy() and memcmp() issues, e.g.:

    void network_func(DEVICE *dev, ETH_MAC *mac)
    {
      ETH_MAC other_mac;

      /* ...code... */

      /* memcpy() bug: */
      memcpy(other_mac, mac, sizeof(ETH_MAC));

      /* or worse: */
      memcpy(mac, other_mac, sizeof(ETH_MAC));
    }

eth_copy_mac() and eth_mac_cmp() replace calls to memcpy() and memcmp() that copy or compare Ethernet MAC addresses. These are type-enforcing functions, i.e., the parameters are ETH_MAC-s, to avoid the subtle memcpy() and memcmp() bugs.

This fix solves at least one Heisenbug in _eth_close() while free()-ing write request buffers (and possibly other Heisenbugs.)