### PR TITLE
Avoid name space collision for the global variables PC, SP and BC whe…

### DIFF
--- a/ALTAIR/altair_defs.h
+++ b/ALTAIR/altair_defs.h
@@ -40,3 +40,6 @@
 #define STOP_IBKPT      3                                /* breakpoint */
 #define STOP_OPCODE     4
 
+/* Rename of global BC and SP variables to avoid namespace conflicts on some platforms */
+#define BC BC_Global
+#define SP SP_Global

--- a/Intel-Systems/Intel-MDS/system_defs.h
+++ b/Intel-Systems/Intel-MDS/system_defs.h
@@ -31,6 +31,11 @@
 #include <string.h>
 #include "sim_defs.h"                   /* simulator defns */
 
+/* Rename of global PC, BC and SP variables to avoid namespace conflicts on some platforms */
+#define PC PC_Global
+#define BC BC_Global
+#define SP SP_Global
+
 #define SET_XACK(VAL)   (xack = VAL)
 
 #define I3214_NUM       0

--- a/LGP/lgp_defs.h
+++ b/LGP/lgp_defs.h
@@ -31,6 +31,10 @@
 
 #include "sim_defs.h"                                   /* simulator defns */
 
+/* Rename of global PC variable to avoid namespace conflicts on some platforms */
+#define PC PC_Global
+
+
 #if defined(USE_INT64) || defined(USE_ADDR64)
 #error "LGP-30 does not support 64b values!"
 #endif

--- a/NOVA/nova_defs.h
+++ b/NOVA/nova_defs.h
@@ -51,6 +51,9 @@
 
 #include "sim_defs.h"                                   /* simulator defns */
 
+/* Rename of global SP variable to avoid namespace conflicts on some platforms */
+#define SP SP_Global
+
 #if (defined(USE_INT64) && !defined(ECLIPSE)) || defined(USE_ADDR64)
 #error "Nova does not support 64b values!"
 #endif

--- a/PDP10/kx10_defs.h
+++ b/PDP10/kx10_defs.h
@@ -30,6 +30,9 @@
 
 #include "sim_defs.h"                                   /* simulator defns */
 
+/* Rename of global PC variable to avoid namespace conflicts on some platforms */
+#define PC PC_Global
+ 
 #if defined(USE_ADDR64)
 #error "PDP-10 does not support 64b addresses!"
 #endif

--- a/sigma/sigma_defs.h
+++ b/sigma/sigma_defs.h
@@ -34,6 +34,10 @@
 
 #include "sim_defs.h"                                   /* simulator defns */
 
+/* Rename of global PC variable to avoid namespace conflicts on some platforms */
+#define PC PC_Global
+
+
 #if defined(USE_INT64) || defined(USE_ADDR64)
 #error "Sigma 32b does not support 64b values!"
 #endif

--- a/swtp6800/swtp6800/swtp_defs.h
+++ b/swtp6800/swtp6800/swtp_defs.h
@@ -27,9 +27,10 @@ Copyright (c) 2005-2012, William Beech
 #include <ctype.h>
 #include "sim_defs.h"                   // simulator defs
 
-/* Rename of global PC variable to avoid namespace conflicts on some platforms */
+/* Rename of global PC and SP variables to avoid namespace conflicts on some platforms */
 
 #define PC PC_Global
+#define SP SP_Global
 
 //#define DONT_USE_INTERNAL_ROM 1
 


### PR DESCRIPTION
…n readline is dynamically loaded. 
This fixes #458 for all affected simulators.