### PR TITLE
3B2: Multiple bugfixes and improvements

### DIFF
--- a/3B2/3b2_cpu.c
+++ b/3B2/3b2_cpu.c
@@ -355,11 +355,15 @@ static const char *att3b2_clock_precalibrate_commands[] = {
 
 MTAB cpu_mod[] = {
 #if defined(REV2)
-    { UNIT_MSIZE, (1u << 20), NULL, "1M",
+    { UNIT_MSIZE, MSIZ_512K, NULL, "512K",
+      &cpu_set_size, NULL, NULL, "Set Memory to 512K bytes" },
+    { UNIT_MSIZE, MSIZ_1M, NULL, "1M",
       &cpu_set_size, NULL, NULL, "Set Memory to 1M bytes" },
-    { UNIT_MSIZE, (1u << 21), NULL, "2M",
+    { UNIT_MSIZE, MSIZ_2M, NULL, "2M",
       &cpu_set_size, NULL, NULL, "Set Memory to 2M bytes" },
-    { UNIT_MSIZE, (1u << 22), NULL, "4M",
+    { UNIT_MSIZE, MSIZ_3M, NULL, "3M",
+      &cpu_set_size, NULL, NULL, "Set Memory to 3M bytes" },
+    { UNIT_MSIZE, MSIZ_4M, NULL, "4M",
       &cpu_set_size, NULL, NULL, "Set Memory to 4M bytes" },
 #endif
 #if defined(REV3)

--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -97,6 +97,7 @@
 #define MSIZ_512K      0x80000
 #define MSIZ_1M        0x100000
 #define MSIZ_2M        0x200000
+#define MSIZ_3M        0x300000
 #define MSIZ_4M        0x400000
 #define MSIZ_8M        0x800000
 #define MSIZ_16M       0x1000000
@@ -146,6 +147,7 @@ extern DEVICE cpu_dev;
 extern DEVICE csr_dev;
 extern DEVICE ctc_dev;
 extern DEVICE dmac_dev;
+extern DEVICE ha_dev;
 extern DEVICE id_dev;
 extern DEVICE if_dev;
 extern DEVICE iu_timer_dev;
@@ -161,7 +163,6 @@ extern DEVICE tto_dev;
 extern DEVICE lpt_dev;
 #if defined(REV3)
 extern DEVICE flt_dev;
-extern DEVICE ha_dev;
 #endif /* defined(REV3) */
 
 #endif /* _3B2_DEFS_H_ */

--- a/3B2/3b2_id.h
+++ b/3B2/3b2_id.h
@@ -69,6 +69,7 @@
 #define ID_STAT_CEL     0x20
 #define ID_STAT_CEH     0x40
 #define ID_STAT_CB      0x80
+#define ID_IRQ_MASK     (ID_STAT_CEL|ID_STAT_CEH|ID_STAT_SRQ)
 
 #define ID_IST_SEN      0x80    /* Seek End        */
 #define ID_IST_RC       0x40    /* Ready Change    */
@@ -105,7 +106,7 @@
 #define ID_CYL_SIZE        ID_SEC_SIZE * ID_SEC_CNT
 
 /* Specific to each drive type */
-#define ID_MAX_DTYPE       3
+#define ID_MAX_DTYPE       4
 
 #define ID_HD30_DTYPE      0
 #define ID_HD30_CYL        697
@@ -122,24 +123,19 @@
 #define ID_HD72C_HEADS     11
 #define ID_HD72C_LBN       149292
 
-/* The HD135 is actually just an HD161 with only 1024 cylinders
- * formatted. This is a software limitation, not hardware. */
-
 #define ID_HD135_DTYPE     3
-#define ID_HD135_CYL       1224
+#define ID_HD135_CYL       1024
 #define ID_HD135_HEADS     15
-#define ID_HD135_LBN       330480
+#define ID_HD135_LBN       276480
 
-#define ID_HD161_DTYPE     3
+#define ID_HD161_DTYPE     4
 #define ID_HD161_CYL       1224
 #define ID_HD161_HEADS     15
 #define ID_HD161_LBN       330480
 
 #define ID_V_DTYPE         (DKUF_V_UF + 0)
-#define ID_M_DTYPE         3
+#define ID_M_DTYPE         7
 #define ID_DTYPE           (ID_M_DTYPE << ID_V_DTYPE)
-#define ID_V_AUTOSIZE      (ID_V_DTYPE + 2)
-#define ID_AUTOSIZE        (1 << ID_V_AUTOSIZE)
 #define ID_GET_DTYPE(x)    (((x) >> ID_V_DTYPE) & ID_M_DTYPE)
 #define ID_DRV(d)          { ID_##d##_HEADS, ID_##d##_LBN, #d }
 
@@ -156,11 +152,22 @@
 
 #define CMD_NUM       ((id_cmd >> 4) & 0xf)
 
+struct id_state {
+    uint16 cyl;       /* Cylinder the drive is positioned on   */
+    uint8  phn;       /* Physical head number                  */
+    uint8  lhn;       /* Logical head number                   */
+    uint8  lsn;       /* Logical sector number                 */
+    uint8  scnt;      /* Sector count                          */
+    uint8  lcnh;      /* Logical Cylinder Number, high byte    */
+    uint8  lcnl;      /* Logical Cylinder Number, low byte     */
+};
+
 /* Function prototypes */
 
 t_stat id_ctlr_svc(UNIT *uptr);
 t_stat id_unit_svc(UNIT *uptr);
 t_stat id_reset(DEVICE *dptr);
+t_stat id_set_large(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 t_stat id_set_type(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 t_stat id_show_type (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 t_stat id_attach(UNIT *uptr, CONST char *cptr);

--- a/3B2/3b2_mau.c
+++ b/3B2/3b2_mau.c
@@ -305,7 +305,7 @@ DEVICE mau_dev = {
     NULL,                           /* attach routine */
     NULL,                           /* detach routine */
     NULL,                           /* context */
-#ifdef REV3
+#if defined(REV3)
     DEV_DEBUG,                      /* Rev 3 flags: Always required */
 #else
     DEV_DISABLE|DEV_DEBUG,          /* Rev 2 flags: Can be disabled */

--- a/3B2/3b2_rev2_mmu.c
+++ b/3B2/3b2_rev2_mmu.c
@@ -275,7 +275,7 @@ static SIM_INLINE t_stat mmu_check_perm(uint8 flags, uint8 r_acc)
             return SCPE_NXM;
         }
         return SCPE_OK;
-    default:
+    default: /* Read / Write / Execute */
         return SCPE_OK;
     }
 }
@@ -670,14 +670,14 @@ t_stat mmu_decode_paged(uint32 va, uint8 r_acc, t_bool fc,
         /* If this is a write, modify the M bit */
         if (SHOULD_UPDATE_PD_M_BIT(pd)) {
             sim_debug(EXECUTE_MSG, &mmu_dev,
-                      "Updating M bit in PD\n");
+                      "Updating M bit in PD [va=%08x, pd=%08x, r_acc=%d]\n", va, pd, r_acc);
             mmu_update_pd(va, PD_LOC(sd1, va), PD_M_MASK);
         }
 
         /* Modify the R bit and write it back */
         if (SHOULD_UPDATE_PD_R_BIT(pd)) {
             sim_debug(EXECUTE_MSG, &mmu_dev,
-                      "Updating R bit in PD\n");
+                      "Updating R bit in PD [va=%08x, pd=%08x, r_acc=%d]\n", va, pd, r_acc);
             mmu_update_pd(va, PD_LOC(sd1, va), PD_R_MASK);
         }
     }

--- a/3B2/3b2_rev2_sys.c
+++ b/3B2/3b2_rev2_sys.c
@@ -38,6 +38,7 @@
 #include "3b2_iu.h"
 #include "3b2_ni.h"
 #include "3b2_ports.h"
+#include "3b2_scsi.h"
 #include "3b2_mau.h"
 #include "3b2_stddev.h"
 #include "3b2_timer.h"
@@ -60,6 +61,7 @@ DEVICE *sim_devices[] = {
     &if_dev,
     &id_dev,
     &ports_dev,
+    &ha_dev,
     &lpt_dev,
     &ctc_dev,
     &ni_dev,
@@ -78,6 +80,7 @@ void full_reset()
     id_reset(&id_dev);
     csr_reset(&csr_dev);
     ports_reset(&ports_dev);
+    ha_reset(&ha_dev);
     lpt_reset(&lpt_dev);
     ctc_reset(&ctc_dev);
     ni_reset(&ni_dev);

--- a/3B2/CMakeLists.txt
+++ b/3B2/CMakeLists.txt
@@ -32,6 +32,7 @@ add_simulator(3b2
         3b2_io.c
         3b2_ports.c
         3b2_ctc.c
+        3b2_scsi.c
         3b2_ni.c
     INCLUDES
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/3B2/README.md
+++ b/3B2/README.md
@@ -8,7 +8,7 @@ This module contains the source for two simulators:
 
 Full documentation for the 3B2 simulator is available here:
 
-  - https://loomcom.com/3b2/emulator.html
+  - https://loomcom.com/3b2/emulator/
 
 3B2/400 Simulator Devices
 -------------------------
@@ -31,6 +31,7 @@ devices are given in parentheses:
   - CM195A Ethernet Network Interface (NI)
   - CM195B 4-port Serial MUX (PORTS)
   - CM195H Cartridge Tape Controller (CTC)
+  - CM195W SCSI Host Adapter (SCSI)
 
 3B2/700 Simulator Devices
 -------------------------
@@ -49,6 +50,6 @@ devices are given in parentheses:
   - TMS2793 Integrated Floppy Controller (IFLOPPY)
   - Non-Volatile Memory (NVRAM)
   - MM58274C Time Of Day Clock (TOD)
-  - CM195W SCSI Host Adapter (SCSI)
   - CM195A Ethernet Network Interface (NI)
   - CM195B 4-port Serial MUX (PORTS)
+  - CM195W SCSI Host Adapter (SCSI)

--- a/Visual Studio Projects/3B2-400.vcproj
+++ b/Visual Studio Projects/3B2-400.vcproj
@@ -250,6 +250,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\3B2\3b2_scsi.c"
+				>
+			</File>
+			<File
 				RelativePath="..\3B2\3b2_stddev.c"
 				>
 			</File>
@@ -302,6 +306,10 @@
 			</File>
 			<File
 				RelativePath="..\sim_fio.c"
+				>
+			</File>
+			<File
+				RelativePath="..\sim_scsi.c"
 				>
 			</File>
 			<File

--- a/Visual Studio Projects/3B2-400.vcxproj
+++ b/Visual Studio Projects/3B2-400.vcxproj
@@ -263,6 +263,7 @@
     <ClCompile Include="..\3B2\3b2_rev2_csr.c" />
     <ClCompile Include="..\3B2\3b2_rev2_mmu.c" />
     <ClCompile Include="..\3B2\3b2_rev2_sys.c" />
+    <ClCompile Include="..\3B2\3b2_scsi.c" />
     <ClCompile Include="..\3B2\3b2_stddev.c" />
     <ClCompile Include="..\3B2\3b2_sys.c" />
     <ClCompile Include="..\3B2\3b2_timer.c" />
@@ -271,6 +272,7 @@
     <ClCompile Include="..\sim_disk.c" />
     <ClCompile Include="..\sim_ether.c" />
     <ClCompile Include="..\sim_fio.c" />
+    <ClCompile Include="..\sim_scsi.c" />
     <ClCompile Include="..\sim_serial.c" />
     <ClCompile Include="..\sim_sock.c" />
     <ClCompile Include="..\sim_tape.c" />

--- a/Visual Studio Projects/3B2-400.vcxproj.filters
+++ b/Visual Studio Projects/3B2-400.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="..\3B2\3b2_rev2_sys.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\3B2\3b2_scsi.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\3B2\3b2_stddev.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -85,6 +88,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\sim_fio.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sim_scsi.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\sim_serial.c">

--- a/makefile
+++ b/makefile
@@ -2129,7 +2129,7 @@ ATT3B2M400 = ${ATT3B2D}/3b2_cpu.c ${ATT3B2D}/3b2_sys.c \
     ${ATT3B2D}/3b2_if.c ${ATT3B2D}/3b2_id.c \
     ${ATT3B2D}/3b2_dmac.c ${ATT3B2D}/3b2_io.c \
     ${ATT3B2D}/3b2_ports.c ${ATT3B2D}/3b2_ctc.c \
-    ${ATT3B2D}/3b2_ni.c
+    ${ATT3B2D}/3b2_scsi.c ${ATT3B2D}/3b2_ni.c
 ATT3B2M400_OPT = -DUSE_INT64 -DUSE_ADDR64 -DREV2 -I ${ATT3B2D} ${NETWORK_OPT} ${AIO_CCDEFS}
 
 ATT3B2M700 = ${ATT3B2D}/3b2_cpu.c ${ATT3B2D}/3b2_sys.c \
@@ -2878,7 +2878,7 @@ endif
 
 ${BIN}3b2${EXE} : ${ATT3B2M400} ${SIM}
 	${MKDIRBIN}
-	${CC} ${ATT3B2M400} ${SIM} ${ATT3B2M400_OPT} ${CC_OUTSPEC} ${LDFLAGS}
+	${CC} ${ATT3B2M400} ${SCSI} ${SIM} ${ATT3B2M400_OPT} ${CC_OUTSPEC} ${LDFLAGS}
 ifeq (${WIN32},)
 	cp ${BIN}3b2${EXE} ${BIN}3b2-400${EXE}
 else


### PR DESCRIPTION
- Allow 3 MB RAM configuration (previously only 1MB, 2MB, and 4MB configurations were allowed)
- Allow SCSI CIO card to be used under 3B2/400 emulation (previously it could only be used under 3B2/700 emulation)
- Improved CTC, PORTS, and SCSI diagnostic checks
- Fixed a bug in IDISK device that allowed impossible disk configurations

The last update is a breaking change that disables the HD161 disk type by default, since real 3B2 hardware does not support it. The disk type will still allowed in backward compatibility mode through use of the "SET IDISK LARGE" command.