### PR TITLE
CMake: Support RelWithDebInfo configuration

### DIFF
--- a/README-CMake.md
+++ b/README-CMake.md
@@ -398,9 +398,11 @@ simh                      # Top-level SIMH source directory
 +-- BIN                   # Simulator executables (note 1)
 |   +-- Debug
 |   +-- Release
+|   +-- RelWithDebInfo
 |   +-- Win32
 |       +-- Debug
 |       +-- Release
+|       +-- RelWithDebInfo
 +-- cmake                 # CMake modules and build subdirectories
 |   +-- build-vs2022      # Build directory for VS-2022 (note 2)
 |   +-- build-vs2019      # Build directory for VS-2019 (note 2)
@@ -434,7 +436,7 @@ Notes:
      will appear directly underneath the `BIN` directory.
    - Multi-configuration builders (`msbuild`, `xcodebuild`): The simulator
      executables will appear underneath individual configuration subdirectories
-     ("Debug" and "Release").
+     ("Debug", "Release" and "RelWithDebInfo").
    - The Windows platform has its `Win32` subdirectory.
 2. The `cmake-builder.ps1` and `cmake-builder.sh` scripts create the
    `cmake/build-*` subdirectories as needed.

--- a/cmake/cmake-builder.ps1
+++ b/cmake/cmake-builder.ps1
@@ -87,7 +87,8 @@ param (
     [Parameter(Mandatory=$false)]
     [string] $flavor         = "vs2022",
 
-    ## The target build configuration. Valid values: "Release" and "Debug"
+    ## The target build configuration. Valid values: "Release", "Debug" and
+    ## "RelWithDebInfo"
     [Parameter(Mandatory=$false)]
     [string] $config         = "Release",
 
@@ -297,7 +298,7 @@ if (!$testonly)
 }
 
 ## Validate the requested configuration.
-if (!@("Release", "Debug").Contains($config))
+if (!@("Release", "Debug", "RelWithDebInfo").Contains($config))
 {
     @"
 ${scriptName}: Invalid configuration: "${config}".

--- a/cmake/cmake-builder.sh
+++ b/cmake/cmake-builder.sh
@@ -12,7 +12,7 @@ Configure and build simh simulators on Linux and *nix-like platforms.
 --clean (-x)      Remove the build subdirectory
 --generate (-g)   Generate the build environment, don't compile/build
 --cache           '--generate' and show CMake's variable cache
---parallel (-p)   Enable build parallelism (parallel builds)
+--parallel (-p)   Enable parallel builds
 --notest          Do not execute 'ctest' test cases
 --noinstall       Do not install SIMH simulators.
 --testonly        Do not build, execute the 'ctest' test cases
@@ -27,7 +27,8 @@ Configure and build simh simulators on Linux and *nix-like platforms.
                     msys2
                     mingw
                     ucrt
---config (-c)     Specifies the build configuration: 'Release' or 'Debug'
+--config (-c)     Specifies the build configuration: 'Release', 'Debug' or
+                  'RelWithDebInfo'
 
 --target          Build a specific simulator or simulators. Separate multiple
                   targets with a comma, e.g. "--target pdp8,pdp11,vax750,altairz80,3b2"
@@ -211,7 +212,7 @@ while true; do
             ;;
         -c | --config)
             case "$2" in
-                Release|Debug)
+                Release|Debug|RelWithDebInfo)
                     buildConfig=$2
                     shift 2
                     ;;

--- a/cmake/platform-quirks.cmake
+++ b/cmake/platform-quirks.cmake
@@ -80,6 +80,7 @@ if (WIN32)
         if (RELEASE_LTO)
             ## /LTCG: Link-Time Code Generation. Pair with /GL at compile time.
             add_compile_options("$<$<CONFIG:Release>:/GL>")
+            add_compile_options("$<$<CONFIG:RelWithDebInfo>:/GL>")
             add_link_options("$<$<CONFIG:Release>:/LTCG>")
             message(STATUS "Adding LTO to Release compiler and linker flags")
         endif ()
@@ -106,6 +107,9 @@ if (WIN32)
         list(APPEND EXTRA_TARGET_CFLAGS
              "$<$<CONFIG:Debug>:$<$<BOOL:${DEBUG_WALL}>:/W4>>"
              "$<$<CONFIG:Release>:/W3>"
+             "$<$<CONFIG:RelWithDebInfo>:$<$<BOOL:${DEBUG_WALL}>:/W4>>"
+             # 4100: Unused arg warning.
+             "/wd4100"
         )
 
         ## Uncomment this line if you end up with /NODEFAULTLIB warninigs. You will also
@@ -137,6 +141,7 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang")
     LIST(APPEND EXTRA_TARGET_CFLAGS
         "-U__STRICT_ANSI__"
         "$<$<CONFIG:Debug>:$<$<BOOL:${DEBUG_WALL}>:-Wall>>"
+        "$<$<CONFIG:RelWithDebInfo>:$<$<BOOL:${DEBUG_WALL}>:-Wall>>"
         ## Only add if WARNINGS_FATAL set; has undesirable consequences with LTO.
         "$<$<CONFIG:Release>:-Wall>"
     )
@@ -199,6 +204,8 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang")
         message(STATUS "    ${opt_flag}")
         string(REGEX REPLACE "${opt_flag}[ \t\r\n]*" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
         string(APPEND CMAKE_C_FLAGS_RELEASE " ${opt_flag}")
+        string(REGEX REPLACE "${opt_flag}[ \t\r\n]*" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+        string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " ${opt_flag}")
         string(REGEX REPLACE "${opt_flag}[ \t\r\n]*" "" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
         string(APPEND CMAKE_C_FLAGS_MINSIZEREL " ${opt_flag}")
     endforeach ()


### PR DESCRIPTION
Support optimized compiles with debugging info (e.g., "-O2 -g" for GCC/Clang.) Useful with 'valgrind' to produce intelligible output.