### PR TITLE
PDP11: MASSBUS controller clear vs rhwc register

### DIFF
--- a/PDP11/pdp11_rh.c
+++ b/PDP11/pdp11_rh.c
@@ -819,7 +819,8 @@ mb = dptr - mba_dev;
 if (mb >= MBA_NUM)
     return SCPE_NOFNC;
 massbus[mb].cs1 = CS1_DONE;
-massbus[mb].wc = 0;
+if ((sim_switches & SWMASK ('P')) !=0)
+    massbus[mb].wc = 0;                             /* powerup only */
 massbus[mb].ba = 0;
 massbus[mb].cs2 = 0;
 massbus[mb].db = 0;


### PR DESCRIPTION
On 7/31/2025 Bob Supnik wrote:
Yeah, good catch. I checked the RH11 and RH70 schematics, and WC is built out of four-bit cascaded counters that either lack a CLEAR pin or have it wired to ground (off).