### PR TITLE
AltairZ80: wd179x: Better support for 5.25-inch floppies.

### DIFF
--- a/AltairZ80/s100_64fdc.c
+++ b/AltairZ80/s100_64fdc.c
@@ -82,6 +82,7 @@ extern t_stat set_iobase(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 extern t_stat show_iobase(FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 extern uint32 sim_map_resource(uint32 baseaddr, uint32 size, uint32 resource_type,
                                int32 (*routine)(const int32, const int32, const int32), const char* name, uint8 unmap);
+void wd179x_set_rpm(int rpm);
 
 static t_stat cromfdc_svc (UNIT *uptr);
 
@@ -1586,8 +1587,10 @@ static int32 cromfdc_control(const int32 port, const int32 io, const int32 data)
         }
         if(data & CROMFDC_CTRL_MAXI) {
             wd179x_infop->drivetype = 8;
+            wd179x_set_rpm(360);
         } else {
             wd179x_infop->drivetype = 5;
+            wd179x_set_rpm(300);
         }
 
         if(data & CROMFDC_CTRL_MTRON) {
@@ -1611,6 +1614,7 @@ static int32 cromfdc_control(const int32 port, const int32 io, const int32 data)
         }
 
         sim_debug(DRIVE_MSG, &cromfdc_dev, "CROMFDC: " ADDRESS_FORMAT " WR CTRL: sel_drive=%d, drivetype=%d, motor=%d, dens=%d, aw=%d\n", PCX, wd179x_infop->sel_drive, wd179x_infop->drivetype, cromfdc_info->motor_on, wd179x_infop->ddens, cromfdc_info->autowait);
+
     } else { /* I/O Read */
         result = (crofdc_boot) ? 0 : CROMFDC_FLAG_BOOT;
         result |= (wd179x_infop->intrq) ? CROMFDC_FLAG_EOJ : 0;


### PR DESCRIPTION
## AltairZ80: wd179x: Better support for 5.25-inch floppies.

### Summary
Allow wd179x to support both 360 RPM (8") and 300 RPM (5.25") drives.

### Compiled with:

* VS 2022 17.14.12 - vcxproj
* MSVC 19.44.35214.0 - CMake
* MacOS (x64) clang-1700.0.13.5
* Linux gcc 12.2.0-14

### [Automated tests](https://github.com/hharte/altairz80-tests):
SIMH running on Windows, Linux (ARM), MacOS (x64):

[CompuPro CP/M-80](https://schorn.ch/cpm/zip/cpm86.zip)
[CompuPro CP/M-86](https://schorn.ch/cpm/zip/cpm86.zip)
[SCP 86-DOS](https://schorn.ch/cpm/zip/86dos.zip)
[MS-DOS 2.11](https://github.com/hharte/altairz80-packages/tree/main/msdos211_test) - Builds [MS-DOS 2.11 from source](https://github.com/hharte/ms-dos).
[CompuPro CP/M-68K v1.3](https://github.com/hharte/altairz80-packages/tree/main/ccpm68k13) (68000 and 68010 versions)
[CP/M-68K v1.2](https://schorn.ch/cpm/zip/cpm68k.zip)
[Advanced Digital Super-Six CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm2)
[Advanced Digital Super-Six CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/adc_cpm3)
[DIGITEX CP/M 2.2](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm2)
[DIGITEX CP/M 3.0](https://github.com/hharte/altairz80-packages/tree/main/dig_cpm3)
[DIGITEX OASIS multi-user version 5.6](https://github.com/open-simh/simh/pull/github.com/hharte/altairz80-packages/tree/main/dig_oasis56)
[MultiStar: IBC OASIS multi-user version 5.6](https://github.com/hharte/altairz80-packages/blob/main/ibcmcc_oasis56)
[MegaStar: IBC OASIS multi-user version 5.6](https://github.com/hharte/altairz80-packages/blob/main/ibcscc_oasis56)
[CP/M-80 (Altair)](https://schorn.ch/cpm/zip/cpm2.zip) ZEXALL Z80 instruction set test.
[CP/M 3 (Altair)](https://schorn.ch/cpm/zip/cpm3.zip) Banked Memory Test.

FYI, @psco, @deltecent 
