### PR TITLE
SCP: Enable C99 standard 'bool'

### DIFF
--- a/3B2/3b2_mau.h
+++ b/3B2/3b2_mau.h
@@ -186,15 +186,15 @@
 #define MAU_RC_RZ         3            /* Round toward Zero        */
 #endif
 
-#define SFP_SIGN(V)  (((V) >> 31) & 1)
+#define SFP_SIGN(V)  ((((V) >> 31) & 1) != 0)
 #define SFP_EXP(V)   (((V) >> 23) & 0xff)
 #define SFP_FRAC(V)  ((V) & 0x7fffff)
 
-#define DFP_SIGN(V)  (((V) >> 63) & 1)
+#define DFP_SIGN(V)  ((((V) >> 63) & 1) != 0)
 #define DFP_EXP(V)   (((V) >> 52) & 0x7ff)
 #define DFP_FRAC(V)  ((V) & 0xfffffffffffffull)
 
-#define XFP_SIGN(V)  (((V)->sign_exp >> 15) & 1)
+#define XFP_SIGN(V)  ((((V)->sign_exp >> 15) & 1) != 0)
 #define XFP_EXP(V)   ((V)->sign_exp & 0x7fff)
 #define XFP_FRAC(V)  ((V)->frac)
 

--- a/AltairZ80/m68k/example/m68kcpu.c
+++ b/AltairZ80/m68k/example/m68kcpu.c
@@ -1047,7 +1047,7 @@ void m68k_set_irq(unsigned int int_level)
 	/* A transition from < 7 to 7 always interrupts (NMI) */
 	/* Note: Level 7 can also level trigger like a normal IRQ */
 	if(old_level != 0x0700 && CPU_INT_LEVEL == 0x0700)
-		m68ki_cpu.nmi_pending = TRUE;
+		m68ki_cpu.nmi_pending = NMI_TRUE;
 }
 
 void m68k_set_virq(unsigned int level, unsigned int active)

--- a/AltairZ80/m68k/m68k.h
+++ b/AltairZ80/m68k/m68k.h
@@ -38,9 +38,9 @@ extern "C" {
 #define ARRAY_LENGTH(x)         (sizeof(x) / sizeof(x[0]))
 #endif
 
-#ifndef FALSE
-#define FALSE 0
-#define TRUE 1
+#ifndef NMI_FALSE
+#define NMI_FALSE 0
+#define NMI_TRUE 1
 #endif
 
 /* ======================================================================== */

--- a/AltairZ80/m68k/m68kcpu.c
+++ b/AltairZ80/m68k/m68kcpu.c
@@ -1047,7 +1047,7 @@ void m68k_set_irq(unsigned int int_level)
     /* A transition from < 7 to 7 always interrupts (NMI) */
     /* Note: Level 7 can also level trigger like a normal IRQ */
     if(old_level != 0x0700 && CPU_INT_LEVEL == 0x0700)
-        m68ki_cpu.nmi_pending = TRUE;
+        m68ki_cpu.nmi_pending = NMI_TRUE;
 }
 
 void m68k_set_virq(unsigned int level, unsigned int active)

--- a/AltairZ80/m68k/m68kcpu.h
+++ b/AltairZ80/m68k/m68kcpu.h
@@ -2136,7 +2136,7 @@ static inline void m68ki_check_interrupts(void)
 {
     if(m68ki_cpu.nmi_pending)
     {
-        m68ki_cpu.nmi_pending = FALSE;
+        m68ki_cpu.nmi_pending = NMI_FALSE;
         m68ki_exception_interrupt(7);
     }
     else if(CPU_INT_LEVEL > FLAG_INT_MASK)

--- a/AltairZ80/m68k/softfloat/milieu.h
+++ b/AltairZ80/m68k/softfloat/milieu.h
@@ -38,5 +38,5 @@ these four paragraphs for those parts of this code that are retained.
 /*----------------------------------------------------------------------------
 | Symbolic Boolean literals.
 *----------------------------------------------------------------------------*/
-#define FALSE 0
-#define TRUE 1
+#define NMI_FALSE 0
+#define NMI_TRUE 1

--- a/AltairZ80/s100_dazzler.c
+++ b/AltairZ80/s100_dazzler.c
@@ -63,10 +63,10 @@
 */
 VID_DISPLAY *daz_vptr = NULL;
 
-static t_bool daz_0e = 0x00;
-static t_bool daz_0f = 0x80;
+static uint8 daz_0e = 0x00;
+static uint8 daz_0f = 0x80;
 static uint32 daz_addr = 0x0000;
-static t_bool daz_frame = 0x3f;
+static uint8 daz_frame = 0x3f;
 static uint8 daz_res = 32;
 static uint16 daz_pages = 1;
 static uint16 daz_window_width = 640;

--- a/H316/h316_hi.c
+++ b/H316/h316_hi.c
@@ -784,7 +784,7 @@ t_stat hi_attach (UNIT *uptr, CONST char *cptr)
   //    ATTACH HIn llll:w.x.y.z:rrrr - connect via UDP to a remote simh host
   //
   t_stat ret;  char *pfn;  uint16 host = uptr->hline;
-  t_bool fport = sim_switches & SWMASK('P');
+  t_bool fport = ((sim_switches & SWMASK('P')) != 0);
 
   // If we're already attached, then detach ...
   if ((uptr->flags & UNIT_ATT) != 0) detach_unit(uptr);

--- a/H316/h316_mi.c
+++ b/H316/h316_mi.c
@@ -694,7 +694,7 @@ t_stat mi_attach (UNIT *uptr, CONST char *cptr)
   //    ATTACH MIn llll:w.x.y.z:rrrr - connect via UDP to a remote simh host
   //
   t_stat ret;  char *pfn;  uint16 line = uptr->mline;
-  t_bool fport = sim_switches & SWMASK('P');
+  t_bool fport = ((sim_switches & SWMASK('P')) != 0);
 
   // If we're already attached, then detach ...
   if ((uptr->flags & UNIT_ATT) != 0) detach_unit(uptr);

--- a/HP2100/hp2100_defs.h
+++ b/HP2100/hp2100_defs.h
@@ -740,8 +740,8 @@ typedef enum {                                  /* poll synchronization modes */
 /* Flip-flops */
 
 typedef enum {                                  /* flip-flop values */
-    CLEAR = 0,                                  /*   the flip-flop is clear */
-    SET   = 1                                   /*   the flip-flop is set */
+    CLEAR = FALSE,                              /*   the flip-flop is clear */
+    SET   = TRUE                                /*   the flip-flop is set */
     } FLIP_FLOP;
 
 

--- a/HP2100/hp2100_sys.c
+++ b/HP2100/hp2100_sys.c
@@ -4153,7 +4153,7 @@ switch (op_type) {                                      /* dispatch by the opera
 
     case opSCHC:
     case opSCOHC:
-        clear = (instruction & IR_HCF);                 /* set TRUE if the clear-flag bit is set */
+        clear = (instruction & IR_HCF) != 0;            /* set TRUE if the clear-flag bit is set */
 
     /* fall through into the opSC case */
 

--- a/HP3000/hp3000_lp.c
+++ b/HP3000/hp3000_lp.c
@@ -1718,10 +1718,11 @@ return IORETURN (outbound_signals, outbound_value);     /* return the outbound s
 static t_stat xfer_service (UNIT *uptr)
 {
 static t_bool device_flag_last = FALSE;
+const t_bool device_cmd_bool = (device_command ^ J2W10_INSTALLED) != 0;
 t_stat        result;
 OUTBOUND_SET  signals;
 
-device_command_out = device_command ^ J2W10_INSTALLED;  /* set device command out; invert if W10 is installed */
+device_command_out = device_cmd_bool;                   /* set device command out; invert if W10 is installed */
 
 if (lp_dev.flags & DEV_DIAG)                            /* if the DHA is connected */
     result = diag_service (uptr);                       /*   then service the diagnostic hardware */

--- a/I1401/i1401_cd.c
+++ b/I1401/i1401_cd.c
@@ -98,7 +98,7 @@
 
 extern uint8 M[];
 extern int32 ind[64], ssa, iochk;
-extern int32 conv_old;
+extern t_bool conv_old;
 
 int32 s1sel, s2sel, s4sel, s8sel;
 char cdr_buf[(2 * CBUFSIZE) + 1];                       /* > CDR_WIDTH */

--- a/I1401/i1401_cpu.c
+++ b/I1401/i1401_cpu.c
@@ -206,7 +206,7 @@ int32 iochk = 0;                                        /* I/O check stop */
 int32 hst_p = 0;                                        /* history pointer */
 int32 hst_lnt = 0;                                      /* history length */
 InstHistory *hst = NULL;                                /* instruction history */
-t_bool conv_old = 0;                                    /* old conversions */
+t_bool conv_old = FALSE;                                /* old conversions */
 
 extern int32 sim_emax;
 
@@ -1954,7 +1954,7 @@ return SCPE_OK;
 
 t_stat cpu_set_conv (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-conv_old = val;
+conv_old = (val != 0);
 return SCPE_OK;
 }
 

--- a/I1401/i1401_iq.c
+++ b/I1401/i1401_iq.c
@@ -87,7 +87,7 @@ DEVICE inq_dev = {
 t_stat inq_io (int32 flag, int32 mod)
 {
 int32 i, t, wm_seen = 0;
-t_bool use_h = inq_unit.flags & UNIT_PCH;
+t_bool use_h = ((inq_unit.flags & UNIT_PCH) != 0);
 
 ind[IN_INC] = 0;                                        /* clear inq clear */
 switch (mod) {                                          /* case on mod */

--- a/I1401/i1401_sys.c
+++ b/I1401/i1401_sys.c
@@ -200,7 +200,7 @@ return;
 t_stat dcw (FILE *of, int32 op, t_value *val, int32 sw)
 {
 int32 i;
-t_bool use_h = sw & SWMASK ('F');
+t_bool use_h = (sw & SWMASK ('F')) != 0;
 
 fprintf (of, "DCW @%c", bcd2ascii (op, use_h));         /* assume it's data */
 for (i = 1; i < sim_emax; i++) {
@@ -232,7 +232,7 @@ t_stat fprint_sym (FILE *of, t_addr addr, t_value *val,
 {
 int32 op, flags, ilnt, i, t;
 int32 wmch = conv_old? '~': '`';
-t_bool use_h = sw & SWMASK ('F');
+t_bool use_h = (sw & SWMASK ('F')) != 0;
 
 if (sw & SWMASK ('C')) {                                /* character? */
     t = val[0];

--- a/I7094/i7094_defs.h
+++ b/I7094/i7094_defs.h
@@ -476,7 +476,7 @@ t_stat ch6_end_nds (uint32 ch);
 uint32 ch6_set_flags (uint32 ch, uint32 unit, uint32 flags);
 t_stat ch6_err_disc (uint32 ch, uint32 unit, uint32 flags);
 t_stat ch6_req_rd (uint32 ch, uint32 unit, t_uint64 val, uint32 flags);
-t_stat ch6_req_wr (uint32 ch, uint32 unit);
+t_bool ch6_req_wr (uint32 ch, uint32 unit);
 t_bool ch6_qconn (uint32 ch, uint32 unit);
 t_stat ch9_req_rd (uint32 ch, t_uint64 val);
 void ch9_set_atn (uint32 ch);

--- a/Ibm1130/ibm1130_cr.c
+++ b/Ibm1130/ibm1130_cr.c
@@ -723,8 +723,6 @@ static CPCODE cardcode_026C[] =     /* 026 commercial */
     {0x2220,        '('},           /* if ASCII has (, treat like % */
 };
 
-extern int cgi;
-
 static int16 ascii_to_card[256];
 
 static CPCODE *cardcode;

--- a/Ibm1130/ibm1130_defs.h
+++ b/Ibm1130/ibm1130_defs.h
@@ -44,8 +44,8 @@
 /* ------------------------------------------------------------------------ */
 /* Global state */
 
-extern int cgi;                             /* TRUE if we are running as a CGI program */
-extern int cgiwritable;                     /* TRUE if we can write the disk images back to the image file in CGI mode */
+extern t_bool cgi;                          /* TRUE if we are running as a CGI program */
+extern t_bool cgiwritable;                  /* TRUE if we can write the disk images back to the image file in CGI mode */
 extern t_bool sim_gui;
 
 extern uint16 M[];                          /* core memory, up to 32Kwords (note: don't even think about trying 64K) */

--- a/Ibm1130/ibm1130_disk.c
+++ b/Ibm1130/ibm1130_disk.c
@@ -540,7 +540,7 @@ static t_stat dsk_attach (UNIT *uptr, CONST char *cptr)
     }
 
     enable_dms_tracing(sim_switches & SWMASK('D'));
-    raw_disk_debug = sim_switches & SWMASK('G');
+    raw_disk_debug = (sim_switches & SWMASK('G')) != 0;
 
     return SCPE_OK;
 }

--- a/Ibm1130/ibm1130_gui.c
+++ b/Ibm1130/ibm1130_gui.c
@@ -102,7 +102,7 @@ extern int boot_drive;
 extern t_bool program_is_loaded;
 
 #ifndef GUI_SUPPORT
-    void update_gui (int force)               {}        /* stubs for non-GUI builds */
+    void update_gui (t_bool force)            {}     /* stubs for non-GUI builds */
     void forms_check (int set)                {}
     void print_check (int set)                {}
     void keyboard_select (int select)         {}
@@ -403,7 +403,7 @@ static void RepaintRegion (HWND hWnd, int left, int top, int right, int bottom)
  * reflected instantly.
  * ------------------------------------------------------------------------ */
 
-void update_gui (BOOL force)
+void update_gui (t_bool force)
 {   
     int i;
     BOOL state;

--- a/Ibm1130/ibm1130_sca.c
+++ b/Ibm1130/ibm1130_sca.c
@@ -675,7 +675,7 @@ static t_stat sca_svc (UNIT *uptr)
         if (timeout)
             sca_interrupt(SCA_DSW_TIMEOUT);
 
-        any_timer_running = (sca_timer_state[0]| sca_timer_state[1] | sca_timer_state[2]) & SCA_TIMER_RUNNING;
+        any_timer_running = ((sca_timer_state[0]| sca_timer_state[1] | sca_timer_state[2]) & SCA_TIMER_RUNNING) != 0;
     }
 
     if (sca_dsw & SCA_DSW_READY) {              /* if connected */
@@ -1003,7 +1003,7 @@ void xio_sca (int32 iocc_addr, int32 func, int32 modify)
                 sca_toggle_timer(TIMER_3S, msec_now);           /* toggle the 3 sec and 1.35 sec timers accordingly */
                 sca_toggle_timer(TIMER_125S, msec_now);
 
-                any_timer_running = (sca_timer_state[0]| sca_timer_state[1] | sca_timer_state[2]) & SCA_TIMER_RUNNING;
+                any_timer_running = ((sca_timer_state[0]| sca_timer_state[1] | sca_timer_state[2]) & SCA_TIMER_RUNNING) != 0;
             }
 
             if (modify & 0x10) {                    /* bit 11 */

--- a/Ibm1130/ibm1130_stddev.c
+++ b/Ibm1130/ibm1130_stddev.c
@@ -112,8 +112,6 @@ typedef struct tag_os_map {                 /* os_map = overstrike mapping */
     unsigned char inlist[MAX_OS_CHARS];     /* inlist = overstruck ASCII characters, sorted. NOT NULL TERMINATED */
 } OS_MAP;
 
-extern int cgi;
-
 static int32 tti_dsw = 0;                   /* device status words */
 static int32 tto_dsw = 0;
        int32 con_dsw = 0;

--- a/Interdata/id_idc.c
+++ b/Interdata/id_idc.c
@@ -223,7 +223,7 @@ t_stat idc_attach (UNIT *uptr, CONST char *cptr);
 t_stat idc_set_size (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 void idc_wd_byte (uint32 dat);
 t_stat idc_rds (UNIT *uptr);
-t_stat idc_wds (UNIT *uptr);
+t_bool idc_wds (UNIT *uptr);
 t_bool idc_dter (UNIT *uptr, uint32 first);
 void idc_done (uint32 flg);
 

--- a/ND100/nd100_sys.c
+++ b/ND100/nd100_sys.c
@@ -94,7 +94,7 @@ gw(FILE *f)
  */
 
 t_stat
-sim_load(FILE *f, CONST char *buf, CONST char *fnam, t_bool flag)
+sim_load(FILE *f, CONST char *buf, CONST char *fnam, int flag)
 {
         int B, C, E, F, H, I;
         int w, i, rv;

--- a/PDP10/pdp10_ksio.c
+++ b/PDP10/pdp10_ksio.c
@@ -1867,7 +1867,7 @@ return;
 
 /* Build dib_tab from device list */
 
-t_bool build_dib_tab (void)
+t_stat build_dib_tab (void)
 {
 int32 i, j, k;
 DEVICE *dptr;

--- a/PDP11/pdp11_cr.c
+++ b/PDP11/pdp11_cr.c
@@ -1753,7 +1753,7 @@ t_stat cr_set_eof (    UNIT    *uptr,
 {
     if (DEBUG_PRS (cr_dev))
         fprintf (sim_deb, "set_eof\n");
-    eofPending = 1;
+    eofPending = TRUE;
 
     return (SCPE_OK);
 }

--- a/PDP11/pdp11_rq.c
+++ b/PDP11/pdp11_rq.c
@@ -3230,7 +3230,7 @@ t_stat rq_attach (UNIT *uptr, CONST char *cptr)
 {
 MSC *cp = rq_ctxmap[uptr->cnum];
 t_stat r;
-t_bool dontchangecapac = (uptr->flags & UNIT_NOAUTO);
+t_bool dontchangecapac = ((uptr->flags & UNIT_NOAUTO) != 0);
 
 if (drv_tab[GET_DTYPE (uptr->flags)].flgs & RQDF_RO) {
     sim_switches |= SWMASK ('R');

--- a/SAGE/m68k_sys.c
+++ b/SAGE/m68k_sys.c
@@ -231,7 +231,7 @@ error:
     return SCPE_FMT;
 }
 
-t_stat sim_load(FILE* fptr, CONST char* cptr, CONST char* fnam, t_bool flag)
+t_stat sim_load(FILE* fptr, CONST char* cptr, CONST char* fnam, int flag)
 {
     int i,len,rc;
     uint16 data;

--- a/VAX/vax4xx_va.c
+++ b/VAX/vax4xx_va.c
@@ -1384,7 +1384,7 @@ t_stat va_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
 if (vid_active)
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
-va_input_captured = val;
+va_input_captured = (val != 0);
 return SCPE_OK;
 }
 

--- a/VAX/vax4xx_vc.c
+++ b/VAX/vax4xx_vc.c
@@ -544,7 +544,7 @@ t_stat vc_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
 if (vid_active)
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
-vc_input_captured = val;
+vc_input_captured = (val != 0);
 return SCPE_OK;
 }
 

--- a/VAX/vax780_fload.c
+++ b/VAX/vax780_fload.c
@@ -207,7 +207,7 @@ return 0;
 
 /* Read blocks */
 
-t_stat rtfile_read (uint32 block, uint32 count, uint16 *buffer)
+t_bool rtfile_read (uint32 block, uint32 count, uint16 *buffer)
 {
 uint32 i, j;
 uint32 pos;

--- a/VAX/vax_sysdev.c
+++ b/VAX/vax_sysdev.c
@@ -240,7 +240,7 @@ int32 cso_csr = 0;                                      /* control/status */
 int32 cmctl_reg[CMCTLSIZE >> 2] = { 0 };                /* CMCTL reg */
 int32 ka_cacr = 0;                                      /* KA655 cache ctl */
 int32 ka_bdr = BDR_BRKENB;                              /* KA655 boot diag */
-t_bool ka_hltenab = 1;                                  /* Halt Enable / Autoboot flag */
+t_bool ka_hltenab = TRUE;                               /* Halt Enable / Autoboot flag */
 int32 ssc_base = SSCBASE;                               /* SSC base */
 int32 ssc_cnf = 0;                                      /* SSC conf */
 int32 ssc_bto = 0;                                      /* SSC timeout */
@@ -249,7 +249,7 @@ int32 tmr_csr[2] = { 0 };                               /* SSC timers */
 uint32 tmr_tir[2] = { 0 };                              /* curr interval */
 uint32 tmr_tnir[2] = { 0 };                             /* next interval */
 int32 tmr_tivr[2] = { 0 };                              /* vector */
-t_bool tmr_inst[2] = { 0 };                             /* wait instructions vs usecs */
+t_bool tmr_inst[2] = { FALSE, FALSE };                  /* wait instructions vs usecs */
 int32 ssc_adsm[2] = { 0 };                              /* addr strobes */
 int32 ssc_adsk[2] = { 0 };
 int32 cdg_dat[CDASIZE >> 2];                            /* cache data */
@@ -1733,7 +1733,7 @@ return SCPE_OK;
 
 t_stat sysd_set_halt (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-ka_hltenab = val;
+ka_hltenab = (val != 0);
 if (ka_hltenab)
     ka_bdr |= BDR_BRKENB;
 else

--- a/VAX/vax_va.c
+++ b/VAX/vax_va.c
@@ -1198,7 +1198,7 @@ t_stat va_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
 if (vid_active)
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
-va_input_captured = val;
+va_input_captured = (val != 0);
 return SCPE_OK;
 }
 

--- a/VAX/vax_vc.c
+++ b/VAX/vax_vc.c
@@ -1079,7 +1079,7 @@ t_stat vc_set_capture (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
 if (vid_active)
     return sim_messagef (SCPE_ALATT, "Capture Mode Can't be changed with device enabled\n");
-vc_input_captured = val;
+vc_input_captured = (val != 0);
 return SCPE_OK;
 }
 

--- a/cmake/add_simulator.cmake
+++ b/cmake/add_simulator.cmake
@@ -57,9 +57,9 @@ function(build_simcore _targ)
     # don't export out to the dependencies (hence PRIVATE.)
     foreach (lib IN ITEMS "${_targ}" "${sim_aio_lib}")
         set_target_properties(${lib} PROPERTIES
-            C_STANDARD 99
             EXCLUDE_FROM_ALL True
         )
+        target_compile_features(${_targ} PRIVATE c_std_99)
         target_compile_definitions(${lib} PRIVATE USE_SIM_CARD USE_SIM_IMD)
         target_compile_options(${lib} PRIVATE ${EXTRA_TARGET_CFLAGS})
         target_link_options(${lib} PRIVATE ${EXTRA_TARGET_LFLAGS})
@@ -195,9 +195,10 @@ function (simh_executable_template _targ)
 
     add_executable("${_targ}" "${SIMH_SOURCES}")
     set_target_properties(${_targ} PROPERTIES
-        C_STANDARD 99
         RUNTIME_OUTPUT_DIRECTORY ${SIMH_LEGACY_INSTALL}
     )
+    ## Compiler should minimally support C99.
+    target_compile_features(${_targ} PRIVATE c_std_99)
     target_compile_options(${_targ} PRIVATE ${EXTRA_TARGET_CFLAGS})
     target_link_options(${_targ} PRIVATE ${EXTRA_TARGET_LFLAGS})
 

--- a/scp.c
+++ b/scp.c
@@ -4192,7 +4192,7 @@ do {
         continue;
     if (echo)                                           /* echo if -v */
         sim_printf("%s> %s\n", do_position(), cptr);
-    sim_cmd_echoed = echo;
+    sim_cmd_echoed = (echo != 0);
     if (*cptr == ':')                                   /* ignore label */
         continue;
     cptr = get_glyph_cmd (cptr, gbuf);                  /* get command glyph */
@@ -5764,10 +5764,11 @@ return SCPE_OK;
 
 t_stat sim_set_asynch (int32 flag, CONST char *cptr)
 {
+const t_bool flag_bool = (flag != 0);
 if (cptr && (*cptr != 0))                               /* now eol? */
     return SCPE_2MARG;
 #ifdef SIM_ASYNCH_IO
-if (flag == sim_asynch_enabled)                         /* already set correctly? */
+if (flag_bool == sim_asynch_enabled)                    /* already set correctly? */
     return SCPE_OK;
 if (1) {
     uint32 i;
@@ -5779,7 +5780,7 @@ if (1) {
             return sim_messagef (SCPE_ALATT, "Can't change asynch mode with %s device attached\n", dptr->name);
         }
     }
-sim_asynch_enabled = flag;
+sim_asynch_enabled = flag_bool;
 tmxr_change_async ();
 sim_timer_change_asynch ();
 if (1) {
@@ -6944,7 +6945,7 @@ t_stat show_config (FILE *st, DEVICE *dnotused, UNIT *unotused, int32 flag, CONS
 {
 size_t i;
 DEVICE *dptr;
-t_bool only_enabled = (sim_switches & SWMASK ('E'));
+const t_bool only_enabled = ((sim_switches & SWMASK ('E')) != 0);
 
 if (NULL != cptr && (*cptr != 0))
     return SCPE_2MARG;
@@ -11920,7 +11921,7 @@ t_stat reason, bare_reason;
 int32 sim_interval_catchup;
 
 if (stop_cpu) {                                         /* stop CPU? */
-    stop_cpu = 0;
+    stop_cpu = FALSE;
     return SCPE_STOP;
     }
 AIO_UPDATE_QUEUE;
@@ -14002,10 +14003,10 @@ size_t bufsize = sizeof(stackbuf);
 char *buf = stackbuf;
 size_t len;
 va_list arglist;
-t_bool inhibit_message = (!sim_show_message || (stat & SCPE_NOMESSAGE));
+const t_bool inhibit_message = (!sim_show_message || (stat & SCPE_NOMESSAGE) != 0);
 char msg_prefix[32] = "";
 size_t prefix_len;
-t_bool newline_prefix = (*fmt == '\n');
+const t_bool newline_prefix = (*fmt == '\n');
 
 if ((stat == SCPE_OK) && (sim_quiet || (sim_switches & SWMASK ('Q'))))
     return stat;

--- a/sim_card.c
+++ b/sim_card.c
@@ -1251,7 +1251,7 @@ sim_card_attach(UNIT * uptr, CONST char *cptr)
     char                 gbuf[30];
     unsigned int         i;
     char                *saved_filename;
-    t_bool               was_attached = (uptr->flags & UNIT_ATT);
+    t_bool               was_attached = ((uptr->flags & UNIT_ATT) != 0);
     t_addr               saved_pos;
     static int           ebcdic_init = 0;
 

--- a/sim_console.c
+++ b/sim_console.c
@@ -327,7 +327,7 @@ return sim_set_notelnet (0, NULL);
 
 /* Forward declarations */
 
-static t_stat sim_os_fd_isatty (int fd);
+static t_bool sim_os_fd_isatty (int fd);
 
 /* Set/show data structures */
 
@@ -3288,11 +3288,15 @@ return r2;
 
 t_bool sim_ttisatty (void)
 {
-static int answer = -1;
+static int inited = -1;
+static t_bool is_a_tty = FALSE;
 
-if (answer == -1)
-    answer = sim_os_fd_isatty (0);
-return (t_bool)answer;
+if (inited != -1)
+    return is_a_tty;
+
+is_a_tty = sim_os_fd_isatty (0);
+inited = 1;
+return sim_ttisatty();
 }
 
 t_bool sim_fd_isatty (int fd)

--- a/sim_defs.h
+++ b/sim_defs.h
@@ -235,7 +235,7 @@ typedef uint32_t        uint32;
 #endif                                                  /* end standard integers */
 
 typedef int             t_stat;                         /* status */
-typedef int             t_bool;                         /* boolean */
+#include "support/sim_bool.h"                           /* boolean */
 
 /* 64b integers */
 

--- a/sim_ether.h
+++ b/sim_ether.h
@@ -312,7 +312,7 @@ struct eth_device {
   uint32        throttle_packet_time;                   /* time last packet was transmitted */
   uint32        throttle_count;                         /* Total Throttle Delays */
 #if defined (USE_READER_THREAD)
-  int           asynch_io;                              /* Asynchronous Interrupt scheduling enabled */
+  t_bool           asynch_io;                           /* Asynchronous Interrupt scheduling enabled */
   int           asynch_io_latency;                      /* instructions to delay pending interrupt */
   ETH_QUE       read_queue;
   pthread_mutex_t     lock;

--- a/support/sim_bool.h
+++ b/support/sim_bool.h
@@ -1,0 +1,39 @@
+/*~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=
+ * sim_bool.h
+ *
+ * t_bool typedef: If using a C11+ standard-compliant compiler or MS compiler
+ * beyond version 1800, use the builtin boolean type, otherwise, default to int.
+ *~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=*/
+
+#if !defined(SIM_BOOL_H)
+
+/* Boolean flag type: */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1800)
+#  if __STDC_VERSION__ < 202311L || defined(_MSC_VER)
+     /* bool, true, false are keywords in C23. */
+#    include <stdbool.h>
+#  endif
+#  if defined(TRUE)
+#    undef TRUE
+#  endif
+#  if defined(FALSE)
+#    undef FALSE
+#  endif
+#  define HAVE_STDBOOL_TYPE
+#  define TRUE true
+#  define FALSE false
+   typedef bool            t_bool;
+#else
+   /* Not a standard-compliant compiler, default t_bool to int. */
+#  if !defined(TRUE)
+#    define TRUE            1
+#  endif
+#  if !defined(FALSE)
+#    define FALSE           0
+#  endif
+#  undef HAVE_STDBOOL_TYPE
+   typedef int             t_bool;
+#endif
+
+#define SIM_BOOL_H
+#endif


### PR DESCRIPTION
Teach SIMH to make use of the C standard bool type when supported, implemented in the support/sim_bool.h header.

  - If the compiler claims that __STDC_VERSION__ is C99 and above, or if the Microsoft C compiler version is at least 1800, include stdbool.h, typedef t_bool to bool, set TRUE and FALSE to true and false, respectively.

  - If not a standard compliant compiler or older Microsoft compiler, typedef t_bool to int, TRUE = 1 and FALSE = 0 (i.e., the old SIMH settings.)

CMake: Use target_compiler_feature() to baseline C99 dialect.

Make a pass through the SIMH code base for t_bool variable declarations and associated references:

  - Ensure boolean expressions are boolean expressions, e.g., "(foo & mask) != 0" vs. "foo & mask" to remove any ambiguity. Overkill, perhaps, but explicitly and unambiguously Boolean.

  - Fix expressions, declarations where t_bool was assumed to be the same as int.

  - Fix inconsistent function prototypes.

3B2:

  3b2_mau.h: Adjust *_SIGN() macros to produce Boolean expressions.

AltairZ80:

  s100_dazzler.c: Change daz_0e, daz_0f and daz_frame's type from t_bool to
      uint8, remove assumption that t_bool is type-equivalent to int.

  m68k/m68k.h, m68k/m68kcpu.c: Rename TRUE to NMI_TRUE, FALSE to NMI_FALSE
    to resolve namespace collision with SIMH TRUE and FALSE.

H316:

  h316_hi.c, h316_mi.c: Ensure assignment result is Boolean.

  hp2100_defs.h, FLIP_FLOP enum: Alias CLEAR and SET to FALSE and TRUE,
      respectively, to avoid any compiler ambiguity with respect to
      Boolean values.

  hp2100_sys.c: Update assignment to Boolean result.

HP3000:

  hp3000_lp.c: Ensure (device_command ^ J2W10_INSTALLED) evaluates to a
      Boolean expression. Instantiates a separate boolean variable to
      preserve comment formatting.

I1401:

  i1401_cpu.c: Initialize clear to FALSE (vice 0), ensure conv_old is
      assigned a Boolean value in cpu_set_conv() (t_bool is not int32.)

  i1401_iq.c: Assign use_h from a Boolean expression.

  i1401_sys.c: Assign use_h from a Boolean expression in dcw() and
      fprint_sym().

I7094:

  Fix ch6_req_wr() return type: should be t_bool, not t_stat.

Ibm1130:

  ibm1130_cr.c: Remove extraneous extern declaraction for cgi.

  ibm1130_defs.h: Change cgi and cgiwritable's extern declaration type to
      t_bool to be consistent with actual definitions.

  ibm1130_disk.c: Assign raw_disk_debug from a Boolean expression.

  ibm1139_gui.c: Update update_gui() prototype to be consistent across the
      GUI and non-GUI compile paths.

  ibm1130_sca.c: Assign any_timer_running from a Boolean expression.

  ibm1130_stddev.c: Remove extraneous extern declaraction for cgi.

  t_bool for update_gui

Interdata:

  id_idc.c: Fix idc_wds() return type (was t_stat, should be t_bool.)

ND100:

  nd100_sys.c: Update sim_load()'s flag declaration. Should be int, not
      t_bool (flag is an unused parameter.)

PDP10:

  pdp10_ksio.c: Return type from build_dib_tab should be t_stat,
    not t_bool.

PDP11:

  pdp11_cr.c: Assign eof_pending to TRUE (vice 1.)

  pdp11_rq.c: Assign dontchangecapac from Boolean expression.

SAGE:

  m68k_sys.c: Fix sim_load()'s flag parameter type, should be int, not
      t_bool.

VAX:

  vax_sysdev.c: Initialize ka_hltenab, tmr_inst[] to TRUE, FALSE to be
      consistent with t_bool.

  vax_va.c, vax_vc.c, vax4xx_va.c, vax4xx_vc.c: Assign va_input_captured
      from Boolean expression.

  vax780_fload.c: Update rtfile_read() return type to t_bool (not t_stat.)