### PR TITLE
Not finding vmnet shouldn't be a fatal error

### DIFF
--- a/cmake/dep-link.cmake
+++ b/cmake/dep-link.cmake
@@ -351,35 +351,13 @@ if (WITH_NETWORK)
         list(APPEND NETWORK_PKG_STATUS "NAT(SLiRP)")
     endif (WITH_SLIRP)
 
-    if (WITH_VMNET AND APPLE)
-        # CMAKE_OSX_DEPLOYMENT_TARGET is attractive, but not set by default.
-        # See what we're using, either by default or what the user has set.
-        check_c_source_compiles(
-            "
-            #include <Availability.h>
-            #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED < 101000
-            #error macOS too old
-            #endif
-            int main(int argc, char **argv) { return 0; }
-            " TARGETING_MACOS_10_10)
-        if (NOT TARGETING_MACOS_10_10)
-        message(FATAL_ERROR "vmnet.framework requires targeting macOS 10.10 or newer")
-        endif()
-
-        # vmnet requires blocks for its callback parameter, even in vanilla C.
-        # This is only supported in clang, not by GCC. It's default in clang,
-        # but we should be clear about it. Do a feature instead of compiler
-        # check anyways though, in case GCC does add it eventually.
-        check_c_compiler_flag(-fblocks HAVE_C_BLOCKS)
-        if (NOT HAVE_C_BLOCKS)
-            message(FATAL_ERROR "vmnet.framework requires blocks support in the C compiler")
-        endif()
+    if (WITH_VMNET AND VMNET_FOUND)
         target_compile_options(simh_network INTERFACE -fblocks)
 
         target_link_libraries(simh_network INTERFACE "-framework vmnet")
         target_compile_definitions(simh_network INTERFACE HAVE_VMNET_NETWORK)
         list(APPEND NETWORK_PKG_STATUS "macOS vmnet.framework")
-    endif(WITH_VMNET AND APPLE)
+    endif(WITH_VMNET AND VMNET_FOUND)
 
     ## Finally, set the network runtime
     if (NOT network_runtime)

--- a/cmake/dep-locate.cmake
+++ b/cmake/dep-locate.cmake
@@ -54,10 +54,8 @@ if (WITH_NETWORK)
         check_c_source_compiles(
             "
             #include <Availability.h>
-            #if TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED < 101000
-	    #error macOS MAC_OS_X_VERSION_MIN_REQUIRED too old
-	    #else
-	    #error macOS MAC_OS_X_VERSION_MIN_REQUIRED is good
+            #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED < 101000
+	    #error macOS too old
             #endif
             int main(int argc, char **argv) { return 0; }
             " TARGETING_MACOS_10_10)

--- a/makefile
+++ b/makefile
@@ -1063,12 +1063,21 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
         NETWORK_CCDEFS += -DUSE_NETWORK
       endif
     endif
-    # XXX: Check for the target version of macOS, check for -fblocks
+    # XXX: Check for the target version of macOS
     ifeq (Darwin,$(OSTYPE))
-      # Provide support for macOS vmnet.framework (requires 10.10)
-      NETWORK_CCDEFS += -fblocks -DHAVE_VMNET_NETWORK
-      NETWORK_LAN_FEATURES += vmnet.framework
-      NETWORK_LDFLAGS += -framework vmnet
+      # Check if blocks are supported
+      CC_HELP_OUTPUT_CMD = ${CC} --help 2>&1
+      CC_HELP_OUTPUT = $(shell $(CC_HELP_OUTPUT_CMD))
+      ifneq (,$(findstring -fblocks,$(CC_HELP_OUTPUT)))
+        # Provide support for macOS vmnet.framework (requires 10.10)
+        NETWORK_CCDEFS += -fblocks -DHAVE_VMNET_NETWORK
+        NETWORK_LAN_FEATURES += vmnet.framework
+        NETWORK_LDFLAGS += -framework vmnet
+      else
+        $(info *** Warning ***)
+        $(info *** Warning *** No blocks support in the compiler, vmnet.framework will be skipped)
+        $(info *** Warning ***)
+      endif
     endif
     ifeq (slirp,$(shell if ${TEST} -e slirp_glue/sim_slirp.c; then echo slirp; fi))
       NETWORK_CCDEFS += -Islirp -Islirp_glue -Islirp_glue/qemu -DHAVE_SLIRP_NETWORK -DUSE_SIMH_SLIRP_DEBUG slirp/*.c slirp_glue/*.c


### PR DESCRIPTION
Allows the build to continue if vmnet isn't supported, either because the deployment target is too old (before 10.10) or the compiler lacks support for blocks (GCC).

See GH-486. I don't have an older Mac handy to test this with.