### PR TITLE
SCP: Add a -F option to SET <dev> DISABLE command to force detach and cancel

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -1649,7 +1649,9 @@ static const char simh_help2[] =
       " specified device from the configuration.  A DISABLED device is invisible\n"
       " to running programs.  The device can still be RESET, but it cannot be\n"
       " ATTAChed, DETACHed, or BOOTed.  SET <device> ENABLED restores a disabled\n"
-      " device to a configuration.\n\n"
+      " device to a configuration.  The SET <device> DISABLED command has an\n"
+      " optional -F switch which will force units to be detached and removed from\n"
+      " the event queue.\n\n"
       " Most multi-unit devices allow units to be enabled or disabled:\n\n"
       "++SET <unit> ENABLED\n"
       "++SET <unit> DISABLED\n\n"
@@ -6108,8 +6110,12 @@ else {
         return SCPE_OK;
     for (i = 0; i < dptr->numunits; i++) {              /* check units */
         up = (dptr->units) + i;                         /* att or active? */
-        if ((up->flags & UNIT_ATT) || sim_is_active (up))
-            return sim_messagef (SCPE_NOFNC, "%s has attached or busy units\n", sim_dname (dptr));                          /* can't do it */
+        if ((up->flags & UNIT_ATT) || sim_is_active (up)) {
+            if ((sim_switches & SWMASK ('F')) == 0)     /* no forced disable? */
+                return sim_messagef (SCPE_NOFNC, "%s has attached or busy units\n", sim_dname (dptr));                  /* can't do it */
+            sim_cancel (up);
+            (void)scp_detach_unit (dptr, up);
+            }
         }
     dptr->flags = dptr->flags | DEV_DIS;                /* disable */
     }
@@ -16616,11 +16622,14 @@ for (i = 0; (dptr = sim_devices[i]) != NULL; i++) {
             default:
                 break;
             }
-        if (was_disabled)
+        if (was_disabled) {
+            sim_switches |= SWMASK ('F');   /* force complete disable */
             set_dev_enbdis (dptr, NULL, 0, NULL);
+            }
         }
     else
         tstat = SCPE_OK;        /* can't enable, just skip device */
+    sim_switches = saved_switches;
     if (tstat != SCPE_OK) {
         stat = tstat;
         sim_printf ("%s device tests returned: %d - %s\n", dptr->name, SCPE_BARE_STATUS (tstat), sim_error_text (tstat));


### PR DESCRIPTION
Historically some devices may not have been able to be DISABLED once they've been ENABLED.

This change allows such a device to be disabled when SET {-F} <device> DISABLE command is invoked with the -F flag specified.