### PR TITLE
PDP11: Changes for Terak 8510/a simulator

### DIFF
--- a/PDP11/pdp11_cpu.c
+++ b/PDP11/pdp11_cpu.c
@@ -923,6 +923,7 @@ while (reason == 0)  {
             }
         src = ReadCW (trapea | calc_ds (MD_KER));       /* new PC */
         src2 = ReadCW ((trapea + 2) | calc_ds (MD_KER)); /* new PSW */
+        src2 = src2 & cpu_tab[cpu_model].psw;           /* mask off invalid bits */
         t = (src2 >> PSW_V_CM) & 03;                    /* new cm */
         trapea = ~t;                                    /* flag pushes */
         WriteCW (PSW, ((STACKFILE[t] - 2) & 0177777) | calc_ds (t));

--- a/PDP11/pdp11_io_lib.c
+++ b/PDP11/pdp11_io_lib.c
@@ -117,7 +117,7 @@ if (dibp == NULL)
 newba = (uint32) get_uint (cptr, DEV_RDX, IOPAGEBASE+IOPAGEMASK, &r); /* get new */
 if (r != SCPE_OK)
     return r;
-if ((newba <= IOPAGEBASE) ||                            /* > IO page base? */
+if ((newba < IOPAGEBASE) ||                             /* > IO page base? */
     (newba % ((uint32) val)))                           /* check modulus */
     return SCPE_ARG;
 dibp->ba = newba;                                       /* store */
@@ -139,7 +139,7 @@ dptr = find_dev_from_unit (uptr);
 if (dptr == NULL)
     return SCPE_IERR;
 dibp = (DIB *) dptr->ctxt;
-if ((dibp == NULL) || (dibp->ba <= IOPAGEBASE))
+if ((dibp == NULL) || (dibp->ba < IOPAGEBASE))
     return SCPE_IERR;
 if ((sim_switches & SWMASK('H')) || (sim_switch_number == 16))
     radix = 16;


### PR DESCRIPTION
Accept devices mapped at IOPAGEBASE -- text buffer/character generator memory on video board starts at 160000.

Clear invalid PSW bits in trap handler -- system acceptance test writes PSW 113705 to vector 34 (TRAP instruction).