### PR TITLE
SCP: Fix output produced when EXAMINE an array register

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -9733,18 +9733,10 @@ for (rptr = lowr; rptr <= highr; rptr++) {
             if ((idx > lows) && (val == last_val))
                 continue;
             if (idx > val_start+1) {
-                if (idx-1 == val_start+1) {
-                    reason = ex_reg (ofile, val, flag, rptr, idx-1);
-                    sim_switches = saved_switches;
-                    if (reason != SCPE_OK)
-                        return reason;
-                    }
-                else {
-                    if (val_start+1 != idx-1)
-                        fprintf (ofile, "%s[%d]-%s[%d]: same as above\n", rptr->name, val_start+1, rptr->name, idx-1);
-                    else
-                        fprintf (ofile, "%s[%d]: same as above\n", rptr->name, val_start+1);
-                    }
+                if (val_start+1 != idx-1)
+                    fprintf (ofile, "%s[%d]-%s[%d]: same as above\n", rptr->name, val_start+1, rptr->name, idx-1);
+                else
+                    fprintf (ofile, "%s[%d]: same as above\n", rptr->name, val_start+1);
                 }
             sim_last_val = last_val = val;
             val_start = idx;


### PR DESCRIPTION
This problem was a latent bug introduced when summarized array register output was added back in 2013 or 2018.

This fixes the problem reported in https://github.com/open-simh/simh/issues/499