### PR TITLE
Avoid redefining `bool` in GCC 15+

### DIFF
--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -20,9 +20,17 @@ install_arch_linux() {
 
 }
 
+install_redhat() {
+    sudo dnf group install -y "development-tools"
+    sudo dnf install -y cmake ninja-build which g++
+    sudo dnf install -y SDL_ttf-devel
+    sudo dnf install -y freetype-devel
+
+
 install_linux() {
     sudo apt-get update -yqqm
     sudo apt-get install -ym pkg-config
+    sudo apt-get install -ym g++
     sudo apt-get install -ym libpcre3-dev libpng-dev libedit-dev
     sudo apt-get install -ym libegl1-mesa-dev libgles2-mesa-dev
     sudo apt-get install -ym libsdl2-dev libfreetype6-dev libsdl2-ttf-dev
@@ -84,7 +92,7 @@ install_clang64() {
 
 
 case "$1" in
-  osx|macports|linux|mingw32|mingw64|ucrt64|clang64)
+  osx|macports|linux|mingw32|mingw64|redhat|ucrt64|clang64)
     install_"$1"
     ;;
   arch-linux)

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -91,6 +91,8 @@ Before you begin building the simulators, you need the following:
 
       apt: `sudo apt install cmake cmake-data`
 
+      dnf: `sudo dnf install cmake`
+
       pacman: `sudo pacman install cmake`
 
   - macOS: Install `cmake` using your preferred external package management
@@ -277,6 +279,12 @@ binaries.
 
     ```bash
     $ sudo sh .travis/deps.sh linux
+    ```
+
+  - Linux dnf-based distributions (e.g., Fedora, Red Hat):
+
+    ```bash
+    $ sudo sh .travis/deps.sh redhat
     ```
 
   - macOS Homebrew:

--- a/slirp_glue/config-host.h
+++ b/slirp_glue/config-host.h
@@ -12,7 +12,9 @@ typedef int SOCKET;
 #endif
 
 #ifndef  __cplusplus
-typedef int bool;
+    #if !defined(__GNUC__) || (__GNUC__ < 15)
+    typedef int bool;
+    #endif
 #endif
 #ifdef _MSC_VER
 #include <win32/stdint.h>


### PR DESCRIPTION
On c23 and onwards, `null` is a keyword and can't be redefined when compiling with GCC 15. This change checks for GCC and the GCC version and skips the line if that's the case.