### PR TITLE
Skip redefinition of bool if running GCC >= 15.

### DIFF
--- a/slirp_glue/config-host.h
+++ b/slirp_glue/config-host.h
@@ -12,7 +12,9 @@ typedef int SOCKET;
 #endif
 
 #ifndef  __cplusplus
-typedef int bool;
+    #if !defined(__GNUC__) || (__GNUC__ < 15)
+    typedef int bool;
+    #endif
 #endif
 #ifdef _MSC_VER
 #include <win32/stdint.h>


### PR DESCRIPTION
For c23, `bool` is a keyword and can't be redefined. This skips the redefinition if we are compiling with GCC >= 15 (default on Fedora 42).