### PR TITLE
Fix bool typedef slirp glue

### DIFF
--- a/slirp_glue/config-host.h
+++ b/slirp_glue/config-host.h
@@ -12,7 +12,7 @@ typedef int SOCKET;
 #endif
 
 #ifndef  __cplusplus
-#if __STDC_VERSION__ >= 202300L
+#if __STDC_VERSION__ < 202300L
 typedef int bool;
 #endif
 #endif

--- a/slirp_glue/config-host.h
+++ b/slirp_glue/config-host.h
@@ -12,7 +12,9 @@ typedef int SOCKET;
 #endif
 
 #ifndef  __cplusplus
+#if __STDC_VERSION__ >= 202300L
 typedef int bool;
+#endif
 #endif
 #ifdef _MSC_VER
 #include <win32/stdint.h>


### PR DESCRIPTION
This PR fixes a bug in `slirp_glue/config-host.h` where the `bool` type was not correctly defined in environments using C versions prior to C23 (e.g., C99 or C11). The `typedef` for `bool` is only defined as `int` when the C version is lower than C23. Starting with C23, `bool` is automatically supported, so this typedef is only provided for older C versions.

### Changes:
- Added: Conditional definition of `bool` as `int` for C versions lower than C23.
- No functional changes for C23 or newer versions.
- These changes ensure compatibility with older C versions and avoid conflicts with `bool` in C23 and later.

### Testing:
- This change has been tested on systems using C99 and C11 to ensure that the `bool` type is correctly defined.
- No changes in behavior when using C23 or higher.

### Additional Notes:
- This change is backward-compatible and should not interfere with existing implementations.
