### PR TITLE
SCP: Acqire mutexes for both cond signals and waits

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -437,12 +437,13 @@ else {
         uptr->a_next = q;                               /* Mark as on list */
         } while (q != AIO_QUEUE_SET(uptr, q));
     }
-AIO_IUNLOCK;
 sim_asynch_check = 0;                             /* try to force check */
 if (sim_idle_wait) {
     sim_debug (TIMER_DBG_IDLE, &sim_timer_dev, "waking due to event on %s after %d %s\n", sim_uname(uptr), event_time, sim_vm_interval_units);
+    /* sim_asynch_lock must remain acquired during the condition signal. */
     pthread_cond_signal (&sim_asynch_wake);
     }
+AIO_IUNLOCK;
 }
 #else
 t_bool sim_asynch_enabled = FALSE;

--- a/sim_console.c
+++ b/sim_console.c
@@ -3162,6 +3162,7 @@ sim_debug (DBG_ASY, &sim_con_telnet, "_console_poll() - starting\n");
 
 pthread_mutex_lock (&sim_tmxr_poll_lock);
 pthread_cond_signal (&sim_console_startup_cond);   /* Signal we're ready to go */
+/* We still have the poll lock acquired entering the loop. */
 while (sim_asynch_enabled) {
 
     if (!sim_is_running) {

--- a/sim_ether.c
+++ b/sim_ether.c
@@ -1994,7 +1994,7 @@ _eth_callback((u_char *)opaque, &header, buf);
 static void *
 _eth_reader(void *arg)
 {
-ETH_DEV* volatile dev = (ETH_DEV*)arg;
+ETH_DEV* volatile dev = (ETH_DEV *) arg;
 int status = 0;
 int sel_ret = 0;
 int do_select = 0;
@@ -2027,6 +2027,11 @@ sim_debug(dev->dbit, dev->dptr, "Reader Thread Starting\n");
    thread which, in general, won't be readily yielding the processor
    when this thread needs to run */
 sim_os_set_thread_priority (PRIORITY_ABOVE_NORMAL);
+
+/* Signal that we've started... */
+pthread_mutex_lock(&dev->startup_mtx);
+pthread_cond_signal(&dev->startup_cond);
+pthread_mutex_unlock(&dev->startup_mtx);
 
 while (dev->handle) {
 #if defined (_WIN32)
@@ -2212,7 +2217,7 @@ return NULL;
 static void *
 _eth_writer(void *arg)
 {
-ETH_DEV* volatile dev = (ETH_DEV*)arg;
+ETH_DEV* volatile dev = (ETH_DEV *) arg;
 ETH_WRITE_REQUEST *request = NULL;
 
 /* Boost Priority for this I/O thread vs the CPU instruction execution
@@ -2221,6 +2226,11 @@ ETH_WRITE_REQUEST *request = NULL;
 sim_os_set_thread_priority (PRIORITY_ABOVE_NORMAL);
 
 sim_debug(dev->dbit, dev->dptr, "Writer Thread Starting\n");
+
+/* Signal that we've started... */
+pthread_mutex_lock(&dev->startup_mtx);
+pthread_cond_signal(&dev->startup_cond);
+pthread_mutex_unlock(&dev->startup_mtx);
 
 pthread_mutex_lock (&dev->writer_lock);
 while (dev->handle) {
@@ -2760,6 +2770,8 @@ dev->dbit = dbit;
 #if defined (USE_READER_THREAD)
 if (1) {
   pthread_attr_t attr;
+  char thr_name[16];
+  const size_t n_thr_name = sizeof(thr_name) / sizeof(char);
 
   ethq_init (&dev->read_queue, 200);         /* initialize FIFO queue */
   pthread_mutex_init (&dev->lock, NULL);
@@ -2778,8 +2790,21 @@ if (1) {
     }
   }
 #endif /* defined(__hpux) */
-  pthread_create (&dev->reader_thread, &attr, _eth_reader, (void *)dev);
-  pthread_create (&dev->writer_thread, &attr, _eth_writer, (void *)dev);
+  pthread_cond_init (&dev->startup_cond, NULL);
+  pthread_mutex_init (&dev->startup_mtx, NULL);
+  pthread_mutex_lock (&dev->startup_mtx);
+  pthread_create (&dev->reader_thread, &attr, _eth_reader, dev);
+  pthread_cond_wait(&dev->startup_cond, &dev->startup_mtx);
+  snprintf(thr_name, n_thr_name - 1, "r: %s", dev->name); 
+  thr_name[n_thr_name - 1] = '\0'; 
+  pthread_setname_np(dev->reader_thread, thr_name);
+  /* pthread_cond_wait() returns with startup_mtx locked. */
+  pthread_create (&dev->writer_thread, &attr, _eth_writer, dev);
+  pthread_cond_wait(&dev->startup_cond, &dev->startup_mtx);
+  snprintf(thr_name, n_thr_name - 1, "w: %s", dev->name); 
+  thr_name[n_thr_name - 1] = '\0'; 
+  pthread_setname_np(dev->writer_thread, thr_name);
+  pthread_mutex_unlock (&dev->startup_mtx);
   pthread_attr_destroy(&attr);
   }
 #endif /* defined (USE_READER_THREAD */
@@ -2849,11 +2874,15 @@ dev->have_host_nic_phy_addr = 0;
 #if defined (USE_READER_THREAD)
 pthread_join (dev->reader_thread, NULL);
 pthread_mutex_destroy (&dev->lock);
+pthread_mutex_lock(&dev->writer_lock);
 pthread_cond_signal (&dev->writer_cond);
+pthread_mutex_unlock(&dev->writer_lock);
 pthread_join (dev->writer_thread, NULL);
 pthread_mutex_destroy (&dev->self_lock);
 pthread_mutex_destroy (&dev->writer_lock);
 pthread_cond_destroy (&dev->writer_cond);
+pthread_mutex_destroy(&dev->startup_mtx);
+pthread_cond_destroy(&dev->startup_cond);
 if (1) {
   ETH_WRITE_REQUEST *buffer;
    while (NULL != (buffer = dev->write_buffers)) {
@@ -3373,8 +3402,9 @@ memcpy(request->packet.msg, packet->msg, packet->len);
   }
 
 /* Awaken writer thread to perform actual write */
-pthread_mutex_unlock (&dev->writer_lock);
+pthread_mutex_lock (&dev->writer_lock);
 pthread_cond_signal (&dev->writer_cond);
+pthread_mutex_unlock (&dev->writer_lock);
 
 /* Return with a status from some prior write */
 if (routine)

--- a/sim_ether.h
+++ b/sim_ether.h
@@ -325,6 +325,10 @@ struct eth_device {
   int write_queue_peak;
   ETH_WRITE_REQUEST *write_buffers;
   t_stat write_status;
+
+  /* Thread startup state. */
+  pthread_mutex_t startup_mtx;
+  pthread_cond_t  startup_cond;
 #endif
 };
 

--- a/sim_frontpanel.c
+++ b/sim_frontpanel.c
@@ -403,8 +403,8 @@ pthread_setspecific (panel_thread_id, "debugflush");
 
 pthread_mutex_lock (&p->io_lock);
 p->debugflush_thread_running = 1;
-pthread_mutex_unlock (&p->io_lock);
 pthread_cond_signal (&p->startup_done);   /* Signal we're ready to go */
+pthread_mutex_unlock (&p->io_lock);
 msleep (100);
 pthread_mutex_lock (&p->io_lock);
 while (p->sock != INVALID_SOCKET) {
@@ -2157,8 +2157,8 @@ if (!p->parent) {
         }
     }
 p->io_thread_running = 1;
-pthread_mutex_unlock (&p->io_lock);
 pthread_cond_signal (&p->startup_done);   /* Signal we're ready to go */
+pthread_mutex_unlock (&p->io_lock);
 msleep (100);
 pthread_mutex_lock (&p->io_lock);
 while ((p->sock != INVALID_SOCKET) &&
@@ -2460,8 +2460,8 @@ _panel_debug (p, DBG_THR, "Starting", NULL, 0);
 
 pthread_mutex_lock (&p->io_lock);
 p->callback_thread_running = 1;
-pthread_mutex_unlock (&p->io_lock);
 pthread_cond_signal (&p->startup_done);   /* Signal we're ready to go */
+pthread_mutex_unlock (&p->io_lock);
 msleep (100);
 pthread_mutex_lock (&p->io_lock);
 while ((p->sock != INVALID_SOCKET) &&


### PR DESCRIPTION
Acquire enclosing mutex used with pthread_cond_wait() when calling pthread_cond_signal() or pthread_cond_broadcast(). This eliminates the possibility that pthread_cond_wait() misses the corresponding pthread_- cond_signal(). See https://stackoverflow.com/questions/4544234/ for a good diagram that explains the thread interleaving.

Also look for premature mutex unlocks. As the Linux pthread_cond_- signal() man page states, "... if predictable scheduling behavior is required, then that mutex shall be locked by the thread calling pthread_cond_broadcast() or pthread_cond_signal()."

ETH:
- Add startup condvar and mutex, have _eth_reader and _eth_writer signal successful thread startup (as other SIMH threads do.)

- Set thread names for reader and writer threads.