### PR TITLE
SOCK: Fix buffer overreach when simplifying IPv4-mapped IPv6 addresses

### DIFF
--- a/sim_sock.c
+++ b/sim_sock.c
@@ -1235,7 +1235,7 @@ if (connectaddr != NULL) {
     p_getnameinfo((struct sockaddr *)&clientname, size, *connectaddr, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
     if (0 == memcmp("::ffff:", *connectaddr, 7))        /* is this a IPv4-mapped IPv6 address? */
         memmove(*connectaddr, 7+*connectaddr,           /* prefer bare IPv4 address */
-                strlen(*connectaddr) - 7 + 1);          /* length to include terminating \0 */
+                strlen(7+*connectaddr) + 1);            /* length to include terminating \0 */
     }
 
 if (!(opt_flags & SIM_SOCK_OPT_BLOCKING)) {
@@ -1321,7 +1321,7 @@ int ret = 0;
 ret = p_getnameinfo(addr, size, hostnamebuf, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
 if (0 == memcmp("::ffff:", hostnamebuf, 7))        /* is this a IPv4-mapped IPv6 address? */
     memmove(hostnamebuf, 7+hostnamebuf,            /* prefer bare IPv4 address */
-            strlen(hostnamebuf) + 7 - 1);          /* length to include terminating \0 */
+            strlen(7+hostnamebuf) + 1);            /* length to include terminating \0 */
 if (!ret)
     ret = p_getnameinfo(addr, size, NULL, 0, portnamebuf, NI_MAXSERV, NI_NUMERICSERV);
 return ret;


### PR DESCRIPTION
> >      There appears to be a bug in the "_sim_getaddrname" routine
> > within "sim_sock.c".  This code appears:
> >
> >    if (0 == memcmp("::ffff:", hostnamebuf, 7))
> >        memmove(hostnamebuf, 7+hostnamebuf,
> >                strlen(hostnamebuf) + 7 - 1);
> >
> > The intent is to slide the "hostnamebuf" string seven bytes to the
> > left to eliminate the "::ffff:" prefix.  But it appears to move bytes
> > from beyond the end of "hostnamebuf".
> >
> > I believe the last parameter should read "- 7 + 1" instead, as it does
> > in the earlier "memmove" call within "sim_accept_conn_ex".

Indeed this is a bug.  

The negative consequence is very low since it merely picks up some 
7 bytes of data past the end of the NUL byte in the existing string which
is likely still within the calling routine's hostnamebuf buffer.

In any case, a slightly clearer fix would be 

> >                strlen(7+hostnamebuf) + 1);

A similar IPv4-mapped to IPb6 address fixup also existed in sim_accept_conn_ex 
with the correct length argument has been modified in the same way.