### PR TITLE
AltairZ80: Corrects bug in ICOM floppy device

### DIFF
--- a/AltairZ80/s100_icom.c
+++ b/AltairZ80/s100_icom.c
@@ -1434,8 +1434,6 @@ static uint8 ICOM_Command(UNIT *uptr, ICOM_REG *pICOM, int32 Data)
             pICOM->status &= ~ICOM_STAT_DRVFAIL;
             pICOM->status &= ~ICOM_STAT_CRC;
             pICOM->status &= ~ICOM_STAT_DDM;
-            pICOM->rDataBuf = 0;
-            pICOM->wDataBuf = 0;
             break;
 
         case ICOM_CMD_LDCONF:


### PR DESCRIPTION
A hobbyist found an original FDOS for 8" drives (FD360, FD3712) that has turned up a bug in both the FDC+ and AltairZ80 implementation of the FD3712.

In the FDC+, the data pointer into the 128 byte write "shift register" is reset upon receipt of a CLEAR command. The real hardware never resets the shift register, so software should not adjust the pointer either. AltairZ80 may need the same adjustment.