### PR TITLE
Tell cmake to use c99 to fix build with GCC 15

### DIFF
--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -17,6 +17,7 @@ install_arch_linux() {
     sudo pacman -S --noconfirm mesa
     sudo pacman -S --noconfirm libsm
     sudo pacman -S --noconfirm cmake
+    sudo pacman -S --noconfirm sdl2_ttf
 
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ endif()
 
 project(simh VERSION "${SIMH_VERSION}" LANGUAGES C CXX)
 
+## Tell cmake we need c99 because GCC 15 defaults to c23 which breaks things.
+set(CMAKE_C_STANDARD 99)
+
 include(vcpkg-setup)
 include(GNUInstallDirs)
 


### PR DESCRIPTION
GCC 15 uses c23 instead of c17 by default. Apparently c23 is not backwards compatible to older C standards... This prevented me from easily compiling simh so I added a setting to tell cmake to use c99 fixing the compiling errors.

I also added a missing dependency in the dependency checker for arch linux.

Tested on arch linux with GCC 15.2.1

Fixes #490