### PR TITLE
Fix self lockout on VDE socket

### DIFF
--- a/sim_ether.c
+++ b/sim_ether.c
@@ -2358,6 +2358,8 @@ else { /* !tap: */
     const char *devname = savname + 4;
 
     memset(&voa, 0, sizeof(voa));
+    voa.mode = 0600;
+
     if (!strcmp(savname, "vde:vdedevice"))
       return sim_messagef (SCPE_OPENERR, "Eth: Must specify actual vde device name (i.e. vde:/tmp/switch)\n");
     while (isspace(*devname))


### PR DESCRIPTION
SIMH seems to somewhat quietly lock itself out of its own VDE socket because it sets the permission bits to all zero. I found some resources saying SIMH needs to run as root to use VDE, which seems to also stem from this problem. Now it works without running as root