### PR TITLE
IBM701:  Correct the non-working i701_cpu.c file...

### DIFF
--- a/I7000/i701_cpu.c
+++ b/I7000/i701_cpu.c
@@ -783,19 +783,22 @@ cpu_reset(DEVICE * dptr)
 t_stat
 cpu_ex(t_value * vptr, t_addr addr, UNIT * uptr, int32 sw)
 {
-    if (addr >= (MEMSIZE * 2))
+    t_addr a = (addr >> 1) & 03777; /* treat same as memory deposit. */
+    /* THE FOLLOWING HAS NEVER EVER WORKED BECAUSE `MEMSIZE` IS ALWAYS
+       LESS THAN 131072, WHICH IS `SIGN` BIT SET FOR 36-BIT WORD ACCESS!!!!!
+    if ( >= (MEMSIZE * 2)) */
+    if (a >= (MEMSIZE))
         return SCPE_NXM;
     if (vptr == NULL)
         return SCPE_OK;
 
-    *vptr = M[(addr & 07777) >> 1];
-    if ((addr & 0400000) == 0) {
-        if ( addr & 1)
-           *vptr <<= 18;
+    *vptr = M[a] & 0777777777777L;
+    if ((addr & 0400000) == 0) { /* show the full word anyway... */
+        if (addr & 1)
+          *vptr &= RMASK;
         else
-           *vptr &= LMASK;
+          *vptr >>= 18;
     }
-    *vptr &= 0777777777777L;
 
     return SCPE_OK;
 }
@@ -805,20 +808,23 @@ cpu_ex(t_value * vptr, t_addr addr, UNIT * uptr, int32 sw)
 t_stat
 cpu_dep(t_value val, t_addr addr, UNIT * uptr, int32 sw)
 {
-    t_addr      a = (addr >> 1) & 03777;
+    t_addr a = (addr >> 1) & 03777;
 
-    if (addr >= (MEMSIZE * 2))
+    /* THE FOLLOWING HAS NEVER EVER WORKED BECAUSE `MEMSIZE` IS ALWAYS
+       LESS THAN 131072, WHICH IS `SIGN` BIT SET FOR 36-BIT WORD ACCESS!!!!!
+    if (addr >= (MEMSIZE * 2)) */
+    if (a >= (MEMSIZE))
         return SCPE_NXM;
-    if ((addr & 0400000) == 0) {
+    if ((addr & 0400000) == 0) { /* set the full word anyway... */
         if (addr & 1) {
-           M[a] &= LMASK;
-           M[a] |= (val >> 18) & RMASK;
+          M[a] &= LMASK;
+          M[a] |= val & RMASK;
         } else {
-           M[a] &= RMASK;
-           M[a] |= val & LMASK;
+          M[a] &= RMASK;
+          M[a] |= (val << 18) & LMASK;
         }
     } else
-        M[a] = val & 0777777777777L;
+      M[a] = val & 0777777777777L;
     return SCPE_OK;
 }
 
@@ -962,4 +968,3 @@ cpu_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr)
 
 return SCPE_OK;
 }
-


### PR DESCRIPTION
It would be impossible for this file to have ever worked in its current state, although that may be because the calling program(s) have changed their calling argument protocols since this IBM 701 emulator was first written.  The problems were three fold as follows:
1. The checks for address bounds overflow could never work if the 0400000 bit was set for full word access, although I haven't been able to cause this to happen.  This is due to that the total maximum memory size is much less than this size and the check was made without masking out this bit.
2. In the `cpu_ex` function to do with returning the result of a half-word memory access, the outputs were shifted to the right by 18 bits which made the outputs difficult to read.
3. In the `cpu_dep function (the most serious problem), the logic was wrong due to having the value input shifted left by 18 bits such that the effect was to make it appear that even addresses were not being written properly.

Now, all the documented modes to do with EXAMINE and DEPOSIT appear to work as expected, with one able to store values and read them normalling as octal digits , characters, or as disassembled code, all aligned to the right in the simulator console...

Context
I'm trying to understand some IBM 701 programs and need to write some to build up some intuition.

```
sim> SHOW VERSION
IBM 701 simulator Open SIMH V4.1-0 Current
    Simulator Framework Capabilities:
        64b data
        32b addresses
        no Ethernet
        Idle/Throttling support is available
        Virtual Hard Disk (VHD) support
        RAW disk and CD/DVD ROM support
        FrontPanel API Version 12
    Host Platform:
        Compiler: GCC 16.1.1 20260515 (Red Hat 16.1.1-2)
        Simulator Compiled as C arch: x64 (Release Build) on Jul 22 2026 at 15:11:46
        Build Tool: simh-makefile
        Memory Access: Little Endian
        Memory Pointer Size: 64 bits
        Large File (>2GB) support
        SDL Video support: No Video Support
        PCRE2 RegEx (Version 10.47) support for EXPECT commands
        OS clock resolution: 1ms
        Time taken by msleep(1): 1ms
        OS: Linux gordonbgoodbeelink 7.1.4-200.fc44.x86_64 #1 SMP PREEMPT_DYNAMIC Sat Jul 18 19:16:16 UTC 2026 x86_64 GNU/Linux
        Processor Name: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics
        tar tool: tar (GNU tar) 1.35
        curl tool: curl 8.18.0 (x86_64-redhat-linux-gnu) libcurl/8.18.0 OpenSSL/3.5.7 zlib/1.3.1.zlib-ng libidn2/2.3.8 nghttp2/1.68.0 mit-krb5/1.22.2
        git commit id: a1f57fa3+uncommitted-changes
        git commit time: 2026-07-03T13:48:11+0200
```

the simulator configuration file (or commands) which were used when the problem occurred with the actual old behaviour:

```
sim> d 0-2 0
sim> e 0/3
0:	 000000000000
1:	 000000000000
2:	 000000000000
sim> id -m 0-1
0:	tr,1
1:	stop,0
sim> e 0/3
0:	 000000000000
1:	 000000000000
2:	 000000000000
```

The expected behavior as per the changes:

```
sim> d 0-2 0
sim> e 0/3
0:	 000000000000
1:	 000000000000
2:	 000000000000
sim> id -m 0-1
0:	tr,1
1:	stop,0
sim> e -m 0-1
0:	 000000010001  rt  STOP 0000 lt  TR  0001
1:	 000000000000  rt  STOP 0000 lt  STOP  0000
```

These changes make it much easier to compile and run code on the simulator.