### PR TITLE
I701:  Fix i701_sys.c file to properly reflect half-word usage...

### DIFF
--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -138,7 +138,7 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
         t_uint64            lbuff[24];
         int                 i;
 
-        while (sim_fread(cbuf, 2, 80, fileref) == 80) {
+        while (addr < MAXMEMSIZE && sim_fread(cbuf, 2, 80, fileref) == 80) {
 
             /* Bit flip into read buffer */
             for (i = 0; i < 24; i++) {
@@ -165,41 +165,67 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
                 dlen = (int)(lbuff[0] >> 18) & 077777;
             }
             for (; i < 24 && dlen > 0; i++) {
+                if (addr >= MAXMEMSIZE) /* safety check! */
+                    break;
                 M[addr++] = lbuff[i];
                 dlen--;
             }
         }
     } else if (match_ext(fnam, "oct")) {
         while (fgets((char *)buf, 80, fileref) != 0) {
-             for(p = (char *)buf; *p == ' ' || *p == '\t'; p++);
-            /* Grab address */
-             for(addr = 0; *p >= '0' && *p <= '7'; p++)
+            for(p = (char *)buf; *p == ' ' || *p == '\t'; p++);
+            if (*p == '\n' || *p == '\r')
+                continue; /* blank line with no meaningful content! */
+            /* Grab address; these are half-word addresses! */
+            for (addr = 0; *p >= '0' && *p <= '7'; p++)
                 addr = (addr << 3) + *p - '0';
-             while(*p != '\n' && *p != '\0') {
+            while (*p != '\n' && *p != '\0') {
                 for(; *p == ' ' || *p == '\t'; p++);
-                for(wd = 0; *p >= '0' && *p <= '7'; p++)
+                for (wd = 0; *p >= '0' && *p <= '7'; p++)
                     wd = (wd << 3) + *p - '0';
-                if (addr < MAXMEMSIZE)
-                    M[addr++] = wd;
-             }
+                /* `addr` is half-word address! */
+                dlen = addr >> 1; /* `dlen` is full-word address! */
+                if (dlen < MAXMEMSIZE)
+                    if (addr & 1) {
+                        M[dlen] &= LMASK;
+                        M[dlen] |= wd & RMASK;
+                        addr++;
+                    } else {
+                        M[dlen] &= RMASK;
+                        M[dlen] |= (wd << 18) & LMASK;
+                    }
+            }
         }
-    } else if (match_ext(fnam, "txt")) {
+    } else if (match_ext(fnam, "sym")) {
         while (fgets((char *)buf, 80, fileref) != 0) {
-             for(p = (char *)buf; *p == ' ' || *p == '\t'; p++);
-             /* Grab address */
-             for(addr = 0; *p >= '0' && *p <= '7'; p++)
-                addr = (addr << 3) + *p - '0';
-             while(*p == ' ' || *p == '\t') p++;
-             if(sim_strncasecmp(p, "BCD", 3) == 0) {
-                 p += 3;
-                 parse_sym(++p, addr, &cpu_unit, &M[addr], SWMASK('C'));
-             } else if (sim_strncasecmp(p, "OCT", 3) == 0) {
-                 p += 3;
-                 for(; *p == ' ' || *p == '\t'; p++);
-                 parse_sym(p, addr, &cpu_unit, &M[addr], 0);
-             } else {
-                 parse_sym(p, addr, &cpu_unit, &M[addr], SWMASK('M'));
-             }
+            for (p = (char *)buf; *p == ' ' || *p == '\t'; p++);
+            /* any lines with first meaningful char of ';' are comment lines */
+            if (*p == ';' || *p == '\n' || *p == '\r' || *p == '\0')
+                continue; /* skip lines with no meaningful content! */
+            /* Grab address; this is a half-word address! */
+            for (addr = 0; *p >= '0' && *p <= '7'; p++)
+               addr = (addr << 3) + *p - '0';
+            while (*p == ' ' || *p == '\t') p++;
+            if (sim_strncasecmp(p, "BCD", 3) == 0) {
+                p += 3;
+                parse_sym(++p, addr, &cpu_unit, &wd, SWMASK('C'));
+            } else if (sim_strncasecmp(p, "OCT", 3) == 0) {
+                p += 3;
+                for(; *p == ' ' || *p == '\t'; p++);
+                parse_sym(p, addr, &cpu_unit, &wd, 0);
+            } else {
+                parse_sym(p, addr, &cpu_unit, &wd, SWMASK('M'));
+            }
+            /* `addr` is half-word address! */
+            dlen = addr >> 1; /* `dlen` is full-word address! */
+            if (dlen < MAXMEMSIZE)
+                if (addr & 1) {
+                    M[dlen] &= LMASK;
+                    M[dlen] |= wd & RMASK;
+                } else {
+                    M[dlen] &= RMASK;
+                    M[dlen] |= (wd << 18) & LMASK;
+                }
         }
     } else
         return SCPE_ARG;
@@ -277,7 +303,9 @@ parse_addr(DEVICE *dptr, const char *cptr, const char **tptr) {
     if (*cptr == '-') {
         cptr++;
         s = 1;
-    }
+    } else
+        if (*cptr == '+')
+            cptr++;
     while(*cptr >= '0' && *cptr <= '7') {
         v <<= 3;
         v += *cptr++ - '0';
@@ -320,28 +348,14 @@ fprint_sym(FILE * of, t_addr addr, t_value * val, UNIT * uptr, int32 sw)
 
 /* Print value in octal first */
     fputc(' ', of);
-    fprint_val(of, inst, 8, 36, PV_RZRO);
+    fprint_val(of, inst, 8, 18, PV_RZRO);
 
     if (sw & SWMASK('M')) {
-        int     op = (int)(inst >> (12+18));
+        int     op = (int)(inst >> 12);
         int     i;
-        fputs("  rt  ", of);
-        if (op != (040 + 13))
+        if (op != (040 + 13)) /* if EXTR instruction... */
            op &= 037;
-        for(i = 0; base_ops[i].name != NULL; i++) {
-            if (base_ops[i].opbase == op) {
-                fputs(base_ops[i].name, of);
-                break;
-            }
-        }
-        fputc(' ', of);
-        if ((inst >> 18) & 0400000L)
-            fputc('-', of);
-        fprint_val(of, (inst >> 18) & 0000000007777L, 8, 12, PV_RZRO);
-        op = (int)(inst >> 12);
-        fputs(" lt  ", of);
-        if (op != (040 + 13))
-           op &= 037;
+        fputs("      ", of); /* space between octal value and sym value */
         for(i = 0; base_ops[i].name != NULL; i++) {
             if (base_ops[i].opbase == op) {
                 fputs(base_ops[i].name, of);
@@ -407,12 +421,12 @@ parse_sym(CONST char *cptr, t_addr addr, UNIT * uptr, t_value * val, int32 sw)
     while (isspace(*cptr))
         cptr++;
     d = 0;
-    if (sw & SWMASK('M')) {
+    if (sw & SWMASK('M')) { /* symbolic code... */
         t_opcode           *op;
 
         i = 0;
         sign = 0;
-next:
+        
         /* Skip blanks */
         while (isspace(*cptr))
             cptr++;
@@ -429,16 +443,10 @@ next:
         tag = parse_addr(&cpu_dev, opcode, &arg);
         if (*arg != opcode[0])
             d += (t_value)tag;
-        if (*cptr == ',') {
-            d <<= 18;
-            cptr++;
-            goto next;
-        }
-        if (*cptr != '\0')
-            return STOP_UUO;
-        *val = d;
+        /* ignore any following characters, which can be any form of comments */
+        *val = d & 0777777; /* exactly one instructions per line! */
         return SCPE_OK;
-    } else if (sw & SWMASK('C')) {
+    } else if (sw & SWMASK('C')) { /* character string... */
         i = 0;
         while (*cptr != '\0' && i < 6) {
             d <<= 6;
@@ -452,7 +460,8 @@ next:
             d |= 060;
             i++;
         }
-    } else {
+        d &= 0777777777777; /* in case of too many digits, take right ones! */
+    } else { /* octal... */
         if (*cptr == '-') {
             sign = 1;
             cptr++;
@@ -465,8 +474,9 @@ next:
             d <<= 3;
             d |= *cptr++ - '0';
         }
+        d &= 0377777; /* in case of too many digits, take right ones! */
         if (sign)
-            d |= 00400000000000L;
+            d |= 00400000L;
     }
     *val = d;
     return SCPE_OK;


### PR DESCRIPTION
Related to my previous PR #565 to the "i701_cpu.c" file not properly handling that the CPU only deals with 18-bit half-word address although it can handle transferring 36-bit data to/from full-word (even) addresses with a special "minus" instruction flag in which I fixed the `cpu_ex` and `cpu_dep` to properly handly user EVALUATE and DEPOSIT commands from the user interface based on half-word addresses, this does the same thing for the "i701_sys.c" file.

As there are more affecting changes, this PR changes many more functions as follows:
1.  The `sim_load` function used by the LOAD command was not changed related to reading of the ".crd" card reader files as those read 36-bits at a time that can be applied as full words to the memory, which has a 36-bit data bus emulations; however, both the reading of the ".oct" and ".sym" files had to be changed as they both should assume reading data in half-word formats.  Both were in error when a blank line with no data was encountered as in assumuming a zero address and data for such a case; as well as correcting this, the function was adjusted to also ignore lines with lines whose first meaningful character is a ';' character to treat the rest of the line as a comment and to consider any characters following a ';' to be a trailing comment field.  Finally, the writing facility for both types of files is adjusted to write just one half of a word for each data entry and to advance to the next word only after the writing to an odd half-word address for ".oct" files (".sym" files give a new address for each assembly instruction).
2. The `parse_addr` function was modified to accept an optionaly '+' character before the instrunction operand address to be ignored and treated as if there were no character so as to have the default half-word address operand behaviour.  This makes the assembly syntax more flexible as some programmers like to explicitly use the '+' character to make it clear that half-word addressing is being used.
3. The `fprint_sym` function was changed so as to only print one half-word decoding per line of output, be it a character or a symbol decoding and to only show up to six octal values per value to make it clear that these values are half-word values.
4. The `parse_sym` function was adjusted to just take one accept one half-word value and if it is more than a half-word in length to just take the right-most half-word worth.  Also, application of the negative sign bit was corrected to the right bit position for all cases.

I can't see that any user would be satisfied with the IBM 701 simulation and user interface as it was and it seems it was never thoroughly tested...

Context:
I'm trying to understand some IBM 701 programs and need to write some to build up some intuition.

```
sim> show version
IBM 701 simulator Open SIMH V4.1-0 Current
    Simulator Framework Capabilities:
        64b data
        32b addresses
        no Ethernet
        Idle/Throttling support is available
        Virtual Hard Disk (VHD) support
        RAW disk and CD/DVD ROM support
        FrontPanel API Version 12
    Host Platform:
        Compiler: GCC 16.1.1 20260515 (Red Hat 16.1.1-2)
        Simulator Compiled as C arch: x64 (Release Build) on Jul 23 2026 at 11:51:41
        Build Tool: simh-makefile
        Memory Access: Little Endian
        Memory Pointer Size: 64 bits
        Large File (>2GB) support
        SDL Video support: No Video Support
        PCRE2 RegEx (Version 10.47) support for EXPECT commands
        OS clock resolution: 1ms
        Time taken by msleep(1): 1ms
        OS: Linux gordonbgoodbeelink 7.1.4-200.fc44.x86_64 #1 SMP PREEMPT_DYNAMIC Sat Jul 18 19:16:16 UTC 2026 x86_64 GNU/Linux
        Processor Name: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics
        tar tool: tar (GNU tar) 1.35
        curl tool: curl 8.18.0 (x86_64-redhat-linux-gnu) libcurl/8.18.0 OpenSSL/3.5.7 zlib/1.3.1.zlib-ng libidn2/2.3.8 nghttp2/1.68.0 mit-krb5/1.22.2
        git commit id: a1f57fa3+uncommitted-changes
        git commit time: 2026-07-03T13:48:11+0200
```

The simulator configuration file (or commands) which were used when the problem occurred with the actual old behaviour:

```
sim> eval -m tr 42
0:	 000000010042  rt  STOP 0000 lt  TR  0042
sim> eval 4700
0:	 000000004700
sim> d 0/7 10042
sim> e 0/7
0:	 000000000000
1:	 000000000000
2:	 000000000000
3:	 000000000000
4:	 000000000000
5:	 000000000000
6:	 000000000000
sim> e -c 0/7
0:	 000000000000   '      '
1:	 000000000000   '      '
2:	 000000000000   '      '
3:	 000000000000   '      '
4:	 000000000000   '      '
5:	 000000000000   '      '
6:	 000000000000   '      '
sim> e -m 0/7
0:	 000000000000  rt  STOP 0000 lt  STOP  0000
1:	 000000000000  rt  STOP 0000 lt  STOP  0000
2:	 000000000000  rt  STOP 0000 lt  STOP  0000
3:	 000000000000  rt  STOP 0000 lt  STOP  0000
4:	 000000000000  rt  STOP 0000 lt  STOP  0000
5:	 000000000000  rt  STOP 0000 lt  STOP  0000
6:	 000000000000  rt  STOP 0000 lt  STOP  0000
```

The expected behavior as per the changes:

```
sim> eval -m tr 42
0:	 010042      TR  0042
sim> eval 4700
0:	 004700
sim> d 0/7 10042
sim> e 0/7
0:	 010042
1:	 010042
2:	 010042
3:	 010042
4:	 010042
5:	 010042
6:	 010042
sim> e -c 0/7
0:	 010042   '   1 K'
1:	 010042   '   1 K'
2:	 010042   '   1 K'
3:	 010042   '   1 K'
4:	 010042   '   1 K'
5:	 010042   '   1 K'
6:	 010042   '   1 K'
sim> e -m 0/7
0:	 010042      TR  0042
1:	 010042      TR  0042
2:	 010042      TR  0042
3:	 010042      TR  0042
4:	 010042      TR  0042
5:	 010042      TR  0042
6:	 010042      TR  0042
```

Most importantly, the LOAD command now properly accepts a "test.oct" file containing the following, puting the octal data into the proper octal addresses:

```
; a header for the octal test file...

10 000005 ; some random comment
11 000007
12 000000
```

and accepts the following "test.sym" file containing the following, assemblying and storing the proper binary machine instructions and the data into the proper locations while ignoring the comment fields:

```
; LOAD test file of IBM 701 assembly code...

0 ADD 10     ; dummy program comment!
1 ADD, +11
2 STORE,+12
3 STOP,+0

10 OCT 5     ; comments in the data section!
11 OCT 7
12 OCT 0
13 BCD ab c de ; another comment here!

; blank line preceeding the end of file!
```

These changes make the IBM 701 simulator very usable!